### PR TITLE
Prompty.yaml: fix “responses” enum

### DIFF
--- a/Prompty.yaml
+++ b/Prompty.yaml
@@ -38,7 +38,7 @@ properties:
         default: first 
         enum:
           - first
-          - full
+          - all
 
 
   name:


### PR DESCRIPTION
The value was inconsistent with documentation and the one used in promptflow.core.Prompty