### PR TITLE
Update page.mdx

### DIFF
--- a/web/docs/prompty-specification/page.mdx
+++ b/web/docs/prompty-specification/page.mdx
@@ -98,7 +98,7 @@ properties:
   #     - role: system
   #       content: I'm sorry, I don't know that. Would you like me to look it up for you?
   # or point to a file
-  # sample: sample.json
+  # sample: "sample.json"
   # also the user can specify the data on the command line
   # pf flow test --flow p.prompty --input my_sample.json
   # if the user runs this command, the sample from the prompty will be used


### PR DESCRIPTION
Updated to use a string
![image](https://github.com/user-attachments/assets/c77aa397-e378-41ba-a6b0-361f8e1e2b09)

This only worked when I updated it to string, this would be clearer if docs updated 