### PR TITLE
Remove unnecessary reference to Seattle in prompt description

### DIFF
--- a/web/docs/tutorials/using-semantic-kernel/page.mdx
+++ b/web/docs/tutorials/using-semantic-kernel/page.mdx
@@ -160,7 +160,7 @@ public class PromptyExample
         string promptyTemplate = """
             ---
             name: Contoso_Chat_Prompt
-            description: A sample prompt that responds with what Seattle is.
+            description: A sample chat prompt representing an agent for the Contoso Outdoors products retailer.
             authors:
               - ????
             model:


### PR DESCRIPTION
Remove a reference to Seattle that seems to be a copy-paste