### PR TITLE
Add `api_key` to schema

### DIFF
--- a/Prompty.yaml
+++ b/Prompty.yaml
@@ -138,6 +138,10 @@ definitions:
         type: string
         description: Type of the model
         const: azure_openai
+      api_key:
+        type: string
+        description: |
+          API key for the model (recommended to use environment variables - e.g.: `${env:OPENAI_API_KEY}`)
       api_version:
         type: string
         description: Version of the model


### PR DESCRIPTION
I noticed when editing my prompty file in VS Code that it displayed a yellow squiggly line under `api_key` because it wasn't in the schema.

![Screenshot 2024-12-11 at 7 42 03 AM](https://github.com/user-attachments/assets/d1ba339b-8c40-4b41-a4c9-8fdd1d9c99fe)

However, both the extension and the `prompty` CLI in the Python runtime are using the field, because, for both, executing my prompty fails without it and succeeds with it.

I added it to the schema so it's documented and the squiggly line goes away.