### PR TITLE
Let `prompty` CLI accept inputs parameters

### DIFF
--- a/runtime/prompty/prompty/cli.py
+++ b/runtime/prompty/prompty/cli.py
@@ -2,6 +2,7 @@ import os
 import json
 import click
 import importlib
+from typing import Any, Dict, Optional
 
 from pathlib import Path
 from pydantic import BaseModel
@@ -78,14 +79,16 @@ def chat_mode(prompt_path: str):
 
 
 @trace
-def execute(prompt_path: str, raw=False):
+def execute(prompt_path: str, inputs: Optional[Dict[str, Any]] = None, raw=False):
     p = prompty.load(prompt_path)
+
+    inputs = inputs or {}
 
     try:
         # load executor / processor types
         dynamic_import(p.model.configuration["type"])
 
-        result = prompty.execute(p, raw=raw)
+        result = prompty.execute(p, inputs=inputs, raw=raw)
         if issubclass(type(result), BaseModel):
             print("\n", json.dumps(result.model_dump(), indent=4), "\n")
         elif isinstance(result, list):
@@ -98,13 +101,29 @@ def execute(prompt_path: str, raw=False):
         print(f"{type(e).__qualname__}: {e}", "\n")
 
 
+def _attributes_to_dict(
+    ctx: click.Context, attribute: click.Option, attributes: tuple[str, ...]
+) -> dict[str, str]:
+    """Click callback that converts attributes specified in the form `key=value` to a
+    dictionary"""
+    result = {}
+    for arg in attributes:
+        k, v = arg.split("=")
+        if k in result:
+            raise click.BadParameter(f"Attribute {k!r} is specified twice")
+        result[k] = v
+
+    return result
+
+
 @click.command()
 @click.option("--source", "-s", required=True)
 @click.option("--env", "-e", required=False)
 @click.option("--verbose", "-v", is_flag=True)
 @click.option("--chat", "-c", is_flag=True)
+@click.argument("inputs", nargs=-1, callback=_attributes_to_dict)
 @click.version_option()
-def run(source, env, verbose, chat):
+def run(source, env, verbose, chat, inputs):
     # load external env file
     if env:
         print(f"Loading environment variables from {env}")
@@ -124,7 +143,7 @@ def run(source, env, verbose, chat):
     if chat:
         chat_mode(str(prompt_path))
     else:
-        execute(str(prompt_path), raw=verbose)
+        execute(str(prompt_path), inputs=inputs, raw=verbose)
 
 
 if __name__ == "__main__":

--- a/runtime/prompty/prompty/cli.py
+++ b/runtime/prompty/prompty/cli.py
@@ -120,7 +120,16 @@ def _attributes_to_dict(
     return result
 
 
-@click.command()
+@click.command(epilog="""
+\b
+INPUTS: key=value pairs
+    The values can come from:
+    - plain strings - e.g.: question="Does it have windows?"
+    - files - e.g.: question=@question.txt
+    - stdin - e.g.: question=@-
+
+For more information, visit https://prompty.ai/
+""")
 @click.option("--source", "-s", required=True)
 @click.option("--env", "-e", required=False)
 @click.option("--verbose", "-v", is_flag=True)

--- a/runtime/prompty/prompty/cli.py
+++ b/runtime/prompty/prompty/cli.py
@@ -111,6 +111,10 @@ def _attributes_to_dict(
         k, v = arg.split("=")
         if k in result:
             raise click.BadParameter(f"Attribute {k!r} is specified twice")
+        if v == "@-":
+            v = click.get_text_stream("stdin").read()
+        if v.startswith("@"):
+            v = Path(v[1:]).read_text()
         result[k] = v
 
     return result


### PR DESCRIPTION
# Features

## Specify inputs on command-line as a strings

Here I specify a `firstName` and `question` as input parameters and they get passed to the `prompty` execution, overriding the values in the `sample` section of the `.prompty` file:

```shell
$ uv run prompty -s basic.prompty -e .env firstName=Marc question="Does it have windows?"
Loading environment variables from .env
Loading invokers from prompty.azure

 Absolutely, Marc! The Alpine Explorer Tent features numerous mesh windows. 🏕️ 
This allows for great ventilation while keeping those pesky bugs out! 
Perfect for enjoying the beautiful outdoors without compromising on comfort. 🌿✨
```

## Specify input on command-line where value comes from a file

If the value of a parameter starts with an `@`, then it will the value of the parameter from a file -- e.g.:

```shell
$ echo "Does it have a gear loft?" > question.txt

$ uv run prompty -s basic.prompty -e .env firstName=Marc question=@question.txt
Loading environment variables from .env
Loading invokers from prompty.azure

 Absolutely, Marc! The Alpine Explorer Tent comes with a built-in gear loft, perfect for storing your outdoor essentials. It's all about keeping your camping experience organized and stress-free! 🏕️✨
```

## Specify input on command-line where value comes from standard input (stdin)

If the value of a parameter is `@-`, then it will read the value of the parameter from standard input -- e.g.:

```shell
$ echo "Is it waterproof?" | uv run prompty -s basic.prompty -e .env firstName=Marc question=@-
Loading environment variables from .env
Loading invokers from prompty.azure

 Absolutely, Marc! The Alpine Explorer Tent is designed to be waterproof, ensuring you stay dry and comfortable even in unexpected weather conditions. 🌧️🏕️ It's perfect for all your outdoor adventures!
```

## Inspiration/prior art for `@<file>` and `@-` syntax

This is similar to [cURL's ability to read from a file or stdin](https://realguess.net/2015/08/23/curl-read-from-file-or-stdin/), which was the inspiration for this.

## No parameters

Of course if I leave out the parameters, then it uses the default values in the `sample` section of the `.prompty` file:

```shell
$ uv run prompty -s basic.prompty -e .env
Loading environment variables from .env
Loading invokers from prompty.azure

 Hey Seth! 🌄

Our tents are designed with comfort, privacy, and convenience in mind. The **Alpine Explorer Tent** features:

- A **detachable divider** for added privacy
- **Numerous mesh windows** and **adjustable vents** for excellent ventilation
- A **waterproof design** to keep you dry
- A built-in gear loft for storing your outdoor essentials

It's the perfect home away from home, especially in nature! If you have any specific questions or need more info, just let me know! 😊🏕️
```