### PR TITLE
Add env var to disable image parsing

### DIFF
--- a/runtime/prompty/prompty/parsers.py
+++ b/runtime/prompty/prompty/parsers.py
@@ -1,3 +1,4 @@
+import os
 import re
 import base64
 from .core import Prompty
@@ -58,6 +59,9 @@ class PromptyChatParser(Invoker):
         any
             The parsed content
         """
+        if os.getenv("PROMPTY_CHAT_PARSER_DISABLE_IMAGE_PARSING", "false").lower() == "true":
+            return content
+
         # regular expression to parse markdown images
         image = r"(?P<alt>!\[[^\]]*\])\((?P<filename>.*?)(?=\"|\))\)"
         matches = re.findall(image, content, flags=re.MULTILINE)


### PR DESCRIPTION
Added a `PROMPTY_CHAT_PARSER_DISABLE_IMAGE_PARSING=true` environment variable to disable image parsing in the chat parser.

In my use case, I am using Prompty to send a prompt to the LLM that contains Markdown that should be converted to a different format. I do not need Prompty to parse the images and try to send them to the LLM. In fact, this is inconvenient because I don't want to have to copy the images just so Prompty can read them.

An environment variable seems kind of janky perhaps, but it's the best solution I could come up with that doesn't require a lot of changes, because there's a fairly deep call stack so in order to pass a parameter, it would require modifying a lot of code. I'm open to other ideas though.