### PR TITLE
check for both str and Path when executing a prompt

### DIFF
--- a/runtime/prompty/prompty/__init__.py
+++ b/runtime/prompty/prompty/__init__.py
@@ -517,7 +517,7 @@ def execute(
     >>> inputs = {"name": "John Doe"}
     >>> result = prompty.execute("prompts/basic.prompty", inputs=inputs)
     """
-    if isinstance(prompt, str):
+    if isinstance(prompt, (str, Path)):
         path = Path(prompt)
         if not path.is_absolute():
             # get caller's path (take into account trace frame)
@@ -571,7 +571,7 @@ async def execute_async(
     >>> inputs = {"name": "John Doe"}
     >>> result = await prompty.execute_async("prompts/basic.prompty", inputs=inputs)
     """
-    if isinstance(prompt, str):
+    if isinstance(prompt, (str, Path)):
         path = Path(prompt)
         if not path.is_absolute():
             # get caller's path (take into account trace frame)

--- a/runtime/prompty/tests/test_execute.py
+++ b/runtime/prompty/tests/test_execute.py
@@ -2,6 +2,8 @@ import os
 import pytest
 import prompty
 from prompty.invoker import InvokerFactory
+from pathlib import Path
+from typing import Union
 
 from tests.fake_azure_executor import FakeAzureExecutor
 from tests.fake_serverless_executor import FakeServerlessExecutor
@@ -36,9 +38,14 @@ def fake_azure_executor():
         "prompts/groundedness.prompty",
         "prompts/faithfulness.prompty",
         "prompts/embedding.prompty",
+        Path("prompts/basic.prompty"),
+        Path("prompts/context.prompty"),
+        Path("prompts/groundedness.prompty"),
+        Path("prompts/faithfulness.prompty"),
+        Path("prompts/embedding.prompty"),
     ],
 )
-def test_basic_execution(prompt: str):
+def test_basic_execution(prompt: Union[str, Path]):
     result = prompty.execute(prompt)
     print(result)
 
@@ -52,9 +59,14 @@ def test_basic_execution(prompt: str):
         "prompts/groundedness.prompty",
         "prompts/faithfulness.prompty",
         "prompts/embedding.prompty",
+        Path("prompts/basic.prompty"),
+        Path("prompts/context.prompty"),
+        Path("prompts/groundedness.prompty"),
+        Path("prompts/faithfulness.prompty"),
+        Path("prompts/embedding.prompty"),
     ],
 )
-async def test_basic_execution_async(prompt: str):
+async def test_basic_execution_async(prompt: Union[str, Path]):
     result = await prompty.execute_async(prompt)
     print(result)
 


### PR DESCRIPTION
Could also use os.PathLike, which feels more correct but would require another import