### PR TITLE
Fix inputs/outputs fields in to_safe_dict

### DIFF
--- a/runtime/prompty/prompty/core.py
+++ b/runtime/prompty/prompty/core.py
@@ -1,3 +1,4 @@
+import copy
 import os
 import typing
 from collections.abc import AsyncIterator, Iterator
@@ -174,7 +175,7 @@ class Prompty(BaseModel):
                 elif k == "template":
                     d[k] = v.model_dump()
                 elif k == "inputs" or k == "outputs":
-                    d[k] = {k: v.model_dump() for k, v in v.items()}
+                    d[k] = copy.deepcopy(v)
                 elif k == "file":
                     d[k] = (
                         str(self.file.as_posix())

--- a/runtime/prompty/tests/test_core.py
+++ b/runtime/prompty/tests/test_core.py
@@ -1,0 +1,41 @@
+import prompty
+from pathlib import Path
+from prompty.tracer import to_dict
+
+
+class TestCore:
+    def test_prompty_to_dict(self, **kwargs):
+        prompt_file = "prompts/basic.prompty"
+        p = prompty.load(prompt_file)
+        d = to_dict(p)
+        assert d["name"] == "Basic Prompt"
+        assert d["model"]["configuration"]["type"] == "azure"
+        assert d["model"]["configuration"]["azure_deployment"] == "gpt-35-turbo"
+        assert d["template"]["type"] == "jinja2"
+
+
+    def test_prompty_to_safe_dict(self, **kwargs):
+        prompt_file_base = "prompts/fake.prompty"
+        p_base = prompty.load(prompt_file_base)
+        prompt_file = "prompts/chat.prompty"
+        p = prompty.load(prompt_file)
+        p.basePrompty = p_base
+        p.inputs = { "key1": "value1", "key2": "value2" }
+        p.outputs = { "key3": "value3", "key4": "value4" }
+        p.file = "/path/to/file"
+        d = p.to_safe_dict()
+        assert d["name"] == "Basic Prompt"
+        assert d["model"]["configuration"]["type"] == "azure"
+        assert d["model"]["configuration"]["azure_deployment"] == "gpt-35-turbo"
+        assert d["template"]["type"] == "jinja2"
+        assert d["model"]["configuration"]["type"] == "azure"
+        assert d["file"] == "/path/to/file"
+        assert "basePrompty" not in d
+
+
+    def test_prompty_to_safe_dict_file_path(self, **kwargs):
+        prompt_file = "prompts/chat.prompty"
+        p = prompty.load(prompt_file)
+        p.file = Path("/path/to/file")
+        d = p.to_safe_dict()
+        assert d["file"] == "/path/to/file"


### PR DESCRIPTION
Currently, the convertion for "inputs" and "outputs" fields may fail