### PR TITLE
Fix sidebar links not responding to full section clicks

### DIFF
--- a/web/src/components/nav/toc.tsx
+++ b/web/src/components/nav/toc.tsx
@@ -63,8 +63,8 @@ const Toc = ({ index, depth, visible }: Props) => {
             )}
             onClick={() => toggleExpansion(i)}
           >
-            <div className={styles.item}>
-              <a href={item.path} onClick={(e) => e.stopPropagation()}>
+            <div className={styles.item} onClick={(e) => e.stopPropagation()}>
+              <a href={item.path}>
                 {item.document?.title}
               </a>
               {hasChildren(item) && (


### PR DESCRIPTION
The issue may be due to the `click` event being set on different elements inconsistently. Some links work as expected because the `click` event is bound to a `<div>` (i.e., the parent of the `<a>` tag), making the entire section clickable. However, in other cases, the event is bound only to the `<a>` tag, restricting the clickable area to just the text. 

To fix this, ensure the `click` event is consistently applied to the parent `<div>` (or similar containing element) in all cases or wrap the entire clickable section within the `<a>` tag.
