### PR TITLE
OpenAI executor doesn't need the deployment property and it fails when you try to execute any YAML file for this type

### DIFF
--- a/runtime/prompty/prompty/openai/executor.py
+++ b/runtime/prompty/prompty/openai/executor.py
@@ -26,8 +26,7 @@ class OpenAIExecutor(Invoker):
 
         self.api = self.prompty.model.api
         self.parameters = self.prompty.model.parameters
-        self.model = self.prompty.model.configuration["name"]
-        self.deployment = self.prompty.model.configuration["deployment"]
+        self.model = self.prompty.model.configuration["name"]        
 
     def invoke(self, data: typing.Any) -> typing.Any:
         """Invoke the OpenAI API


### PR DESCRIPTION
This pull request includes a small change to the `runtime/prompty/prompty/openai/executor.py` file. The change removes the `deployment` attribute from the `__init__` method, which is no longer needed.