### PR TITLE
fix: 404 link at /docs/getting-started/concepts

### DIFF
--- a/web/docs/getting-started/concepts/page.mdx
+++ b/web/docs/getting-started/concepts/page.mdx
@@ -27,7 +27,7 @@ The Prompty implementation consists of three core components - the _specificatio
 
 ### 1.1 The Prompty Specification
 
-The [Prompty specification](https://github.com/microsoft/prompty/blob/main/Prompty.yaml) defines the core `.prompty` asset file format. We'll look at this in more detail in the [Prompty File Spec](/docs/prompty-file-spec) section of the documentation. For now, click to expand the section below to see a _basic.prompty_ sample and get an intuitive sense for what an asset file looks like.
+The [Prompty specification](https://github.com/microsoft/prompty/blob/main/Prompty.yaml) defines the core `.prompty` asset file format. We'll look at this in more detail in the [Prompty File Spec](/docs/prompty-specification) section of the documentation. For now, click to expand the section below to see a _basic.prompty_ sample and get an intuitive sense for what an asset file looks like.
 
 <details>
 <summary> **Learn More**: The `basic.prompty` asset file </summary>


### PR DESCRIPTION
500/404 status for [/docs/prompty-file-spec](https://prompty.ai/docs/prompty-file-spec) link on [/docs/getting-started/concepts](https://prompty.ai/docs/getting-started/concepts#:~:text=detail%20in%20the-,Prompty%20File%20Spec,-section%20of%20the)