### PR TITLE
Enhance link validation and fix broken links in documentation

### DIFF
--- a/web/astro.config.mjs
+++ b/web/astro.config.mjs
@@ -29,7 +29,9 @@ export default defineConfig({
           href: "https://github.com/microsoft/prompty",
         },
       ],
-      plugins: [starlightAutoSidebar(), starlightLinksValidator()],
+      plugins: [starlightAutoSidebar(), starlightLinksValidator({
+        exclude: ["http://localhost:4321"]
+      })],
       sidebar: [
         {
           label: "Welcome",

--- a/web/astro.config.mjs
+++ b/web/astro.config.mjs
@@ -3,6 +3,7 @@ import { defineConfig, passthroughImageService } from "astro/config";
 import starlight from "@astrojs/starlight";
 import devtoolsJson from "vite-plugin-devtools-json";
 import starlightAutoSidebar from "starlight-auto-sidebar";
+import starlightLinksValidator from "starlight-links-validator";
 
 export default defineConfig({
   site: "https://prompty.ai/",
@@ -28,7 +29,7 @@ export default defineConfig({
           href: "https://github.com/microsoft/prompty",
         },
       ],
-      plugins: [starlightAutoSidebar()],
+      plugins: [starlightAutoSidebar(), starlightLinksValidator()],
       sidebar: [
         {
           label: "Welcome",

--- a/web/package-lock.json
+++ b/web/package-lock.json
@@ -16,6 +16,7 @@
         "starlight-contributor-list": "^0.3.0"
       },
       "devDependencies": {
+        "starlight-links-validator": "^0.17.1",
         "vite-plugin-devtools-json": "^0.2.0"
       }
     },
@@ -1991,6 +1992,12 @@
       "dependencies": {
         "undici-types": "~7.8.0"
       }
+    },
+    "node_modules/@types/picomatch": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/@types/picomatch/-/picomatch-3.0.2.tgz",
+      "integrity": "sha512-n0i8TD3UDB7paoMMxA3Y65vUncFJXjcUf7lQY7YyKGl6031FNjfsLs6pdLFCy2GNFxItPJG8GvvpbZc2skH7WA==",
+      "dev": true
     },
     "node_modules/@types/sax": {
       "version": "1.2.7",
@@ -4038,6 +4045,18 @@
       "license": "MIT",
       "funding": {
         "url": "https://github.com/sponsors/brc-dd"
+      }
+    },
+    "node_modules/is-absolute-url": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/is-absolute-url/-/is-absolute-url-4.0.1.tgz",
+      "integrity": "sha512-/51/TKE88Lmm7Gc4/8btclNXWS+g50wXhYJq8HWIBAGUBnoAdRu1aXeh364t/O7wXDAcTJDP8PNuNKWUDWie+A==",
+      "dev": true,
+      "engines": {
+        "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/is-alphabetical": {
@@ -6677,6 +6696,30 @@
       },
       "peerDependencies": {
         "@astrojs/starlight": ">=0.30"
+      }
+    },
+    "node_modules/starlight-links-validator": {
+      "version": "0.17.1",
+      "resolved": "https://registry.npmjs.org/starlight-links-validator/-/starlight-links-validator-0.17.1.tgz",
+      "integrity": "sha512-d2QoBO3mQPWYq/TO4I0kT/3Z9hFulnMzMPaG2dW0H14hPq4N7ZwiBl2FMrLK8I4UE34sztcBatvWCZc62S0BMQ==",
+      "dev": true,
+      "dependencies": {
+        "@types/picomatch": "^3.0.1",
+        "github-slugger": "^2.0.0",
+        "hast-util-from-html": "^2.0.3",
+        "hast-util-has-property": "^3.0.0",
+        "is-absolute-url": "^4.0.1",
+        "kleur": "^4.1.5",
+        "mdast-util-mdx-jsx": "^3.1.3",
+        "mdast-util-to-string": "^4.0.0",
+        "picomatch": "^4.0.2",
+        "unist-util-visit": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=18.17.1"
+      },
+      "peerDependencies": {
+        "@astrojs/starlight": ">=0.32.0"
       }
     },
     "node_modules/stream-replace-string": {

--- a/web/package.json
+++ b/web/package.json
@@ -18,6 +18,7 @@
     "starlight-contributor-list": "^0.3.0"
   },
   "devDependencies": {
+    "starlight-links-validator": "^0.17.1",
     "vite-plugin-devtools-json": "^0.2.0"
   }
 }

--- a/web/src/content/docs/contributing/code-guidelines.mdx
+++ b/web/src/content/docs/contributing/code-guidelines.mdx
@@ -16,4 +16,4 @@ index: 2
 ..to be updated
 
 ---
-[Want to Contribute To the Project?](/docs/contributing/)
+[Want to Contribute To the Project?](/contributing/)

--- a/web/src/content/docs/contributing/docs-guidelines.mdx
+++ b/web/src/content/docs/contributing/docs-guidelines.mdx
@@ -25,7 +25,7 @@ For contributing to the Prompty documentation:
 
 3. Previewing Changes
     - Start the local development server with `npm run dev` from the `web` directory.
-    - View your changes at [http://localhost:3000](http://localhost:3000).
+    - View your changes at [http://localhost:4321](http://localhost:4321).
     - The site will hot-reload as you edit files.
 
 4. Building Documentation

--- a/web/src/content/docs/contributing/docs-guidelines.mdx
+++ b/web/src/content/docs/contributing/docs-guidelines.mdx
@@ -33,4 +33,4 @@ For contributing to the Prompty documentation:
     - Check for any build errors or warnings before submitting your PR.
 
 ---
-[Want to Contribute To the Project?](/docs/contributing/) - _Updated Guidance Coming Soon_.
+[Want to Contribute To the Project?](/contributing/) - _Updated Guidance Coming Soon_.

--- a/web/src/content/docs/getting-started/concepts.mdx
+++ b/web/src/content/docs/getting-started/concepts.mdx
@@ -67,7 +67,7 @@ The [Prompty specification](https://github.com/microsoft/prompty/blob/main/Promp
 
 ### 1.2 The Prompty Tooling
 
-The [Prompty Visual Studio Code Extension](https://marketplace.visualstudio.com/items?itemName=ms-toolsai.prompty) helps you create, manage, and execute, your `.prompty` assets - effectively giving you a _playground_ right in your editor, to streamline your prompt engineering workflow and speed up your prototype iterations. We'll get hands-on experience with this in the [Tutorials](/docs/tutorials) section. For now, click to expand the section and get an intutive sense for how this enhances your developer experience.
+The [Prompty Visual Studio Code Extension](https://marketplace.visualstudio.com/items?itemName=ms-toolsai.prompty) helps you create, manage, and execute, your `.prompty` assets - effectively giving you a _playground_ right in your editor, to streamline your prompt engineering workflow and speed up your prototype iterations. We'll get hands-on experience with this in the Tutorials section. For now, click to expand the section and get an intutive sense for how this enhances your developer experience.
 
 <details>
 <summary> **Learn More**: The Prompty Visual Studio Code Extension </summary>

--- a/web/src/content/docs/getting-started/concepts.mdx
+++ b/web/src/content/docs/getting-started/concepts.mdx
@@ -125,4 +125,4 @@ Think of it as a **micro-orchestrator focused on a single LLM invocation** putti
 ![Where does this fit?](concepts/03-micro-orchestrator-mindset.png)
 
 ---
-[Want to Contribute To the Project?](/docs/contributing/) - _Updated Guidance Coming Soon_.
+[Want to Contribute To the Project?](/contributing/) - _Updated Guidance Coming Soon_.

--- a/web/src/content/docs/getting-started/concepts.mdx
+++ b/web/src/content/docs/getting-started/concepts.mdx
@@ -27,7 +27,7 @@ The Prompty implementation consists of three core components - the _specificatio
 
 ### 1.1 The Prompty Specification
 
-The [Prompty specification](https://github.com/microsoft/prompty/blob/main/Prompty.yaml) defines the core `.prompty` asset file format. We'll look at this in more detail in the [Prompty File Spec](/docs/prompty-file-spec) section of the documentation. For now, click to expand the section below to see a _basic.prompty_ sample and get an intuitive sense for what an asset file looks like.
+The [Prompty specification](https://github.com/microsoft/prompty/blob/main/Prompty.yaml) defines the core `.prompty` asset file format. We'll look at this in more detail in the [Prompty File Spec](/specification/page/) section of the documentation. For now, click to expand the section below to see a _basic.prompty_ sample and get an intuitive sense for what an asset file looks like.
 
 <details>
 <summary> **Learn More**: The `basic.prompty` asset file </summary>

--- a/web/src/content/docs/getting-started/debugging-prompty.mdx
+++ b/web/src/content/docs/getting-started/debugging-prompty.mdx
@@ -139,7 +139,7 @@ From the output, you can see the difference in the completion tokens and the tim
 
 ## 7. Building a Custom Tracer in Prompty
 
-In the guides section, we will provide a deep dive into [Observability in Prompty](/docs/guides/prompty-observability) and how you can create your own tracer.
+In the guides section, we will provide a deep dive into [Observability in Prompty](/guides/observability/) and how you can create your own tracer.
 
 ---
 [Want to Contribute To the Project?](/contributing/) - _Updated Guidance Coming Soon_.

--- a/web/src/content/docs/getting-started/debugging-prompty.mdx
+++ b/web/src/content/docs/getting-started/debugging-prompty.mdx
@@ -142,4 +142,4 @@ From the output, you can see the difference in the completion tokens and the tim
 In the guides section, we will provide a deep dive into [Observability in Prompty](/docs/guides/prompty-observability) and how you can create your own tracer.
 
 ---
-[Want to Contribute To the Project?](/docs/contributing/) - _Updated Guidance Coming Soon_.
+[Want to Contribute To the Project?](/contributing/) - _Updated Guidance Coming Soon_.

--- a/web/src/content/docs/getting-started/first-prompty.mdx
+++ b/web/src/content/docs/getting-started/first-prompty.mdx
@@ -206,4 +206,4 @@ This is where the _Prompty Runtime_ comes in. The runtime converts the Prompty a
 
 
 ---
-[Want to Contribute To the Project?](/docs/contributing/) - _Updated Guidance Coming Soon_.
+[Want to Contribute To the Project?](/contributing/) - _Updated Guidance Coming Soon_.

--- a/web/src/content/docs/getting-started/index.mdx
+++ b/web/src/content/docs/getting-started/index.mdx
@@ -23,7 +23,7 @@ _In this section we take you from core concepts to code, covering the following 
 
 ## Next Steps
 
-Start with the **[Core Concepts](/docs/getting-started/concepts)** section to learn about the basic building blocks of Prompty.
+Start with the **[Core Concepts](/getting-started/concepts/)** section to learn about the basic building blocks of Prompty.
 
 
 ---

--- a/web/src/content/docs/getting-started/index.mdx
+++ b/web/src/content/docs/getting-started/index.mdx
@@ -28,5 +28,5 @@ Start with the **[Core Concepts](/docs/getting-started/concepts)** section to le
 
 ---
 
-[Want to Contribute To the Project?](/docs/contributing/) - _Guidance coming soon_.
+[Want to Contribute To the Project?](/contributing/) - _Guidance coming soon_.
 

--- a/web/src/content/docs/getting-started/prompty-to-code.mdx
+++ b/web/src/content/docs/getting-started/prompty-to-code.mdx
@@ -205,7 +205,7 @@ if __name__ == "__main__":
 
 ## 7. Additional supported runtimes
 
-The Prompty runtime supports additional runtimes, including frameworks such as [LangChain](/docs/tutorials/using-langchain), and [Semantic Kernel](/docs/tutorials/using-semantic-kernel). In the [tutorials](/docs/tutorials) section, we will cover how to generate code from Prompty assets using these runtimes. (coming soon)
+The Prompty runtime supports additional runtimes, including frameworks such as [LangChain](tutorials/using-langchain/), and [Semantic Kernel](tutorials/using-semantic-kernel/). In the tutorials section, we will cover how to generate code from Prompty assets using these runtimes. (coming soon)
 
 
 ---

--- a/web/src/content/docs/getting-started/prompty-to-code.mdx
+++ b/web/src/content/docs/getting-started/prompty-to-code.mdx
@@ -205,7 +205,7 @@ if __name__ == "__main__":
 
 ## 7. Additional supported runtimes
 
-The Prompty runtime supports additional runtimes, including frameworks such as [LangChain](tutorials/using-langchain/), and [Semantic Kernel](tutorials/using-semantic-kernel/). In the tutorials section, we will cover how to generate code from Prompty assets using these runtimes. (coming soon)
+The Prompty runtime supports additional runtimes, including frameworks such as [LangChain](/tutorials/using-langchain/), and [Semantic Kernel](/tutorials/using-semantic-kernel/). In the tutorials section, we will cover how to generate code from Prompty assets using these runtimes. (coming soon)
 
 
 ---

--- a/web/src/content/docs/getting-started/prompty-to-code.mdx
+++ b/web/src/content/docs/getting-started/prompty-to-code.mdx
@@ -209,4 +209,4 @@ The Prompty runtime supports additional runtimes, including frameworks such as [
 
 
 ---
-[Want to Contribute To the Project?](/docs/contributing/) - _Updated Guidance Coming Soon_.
+[Want to Contribute To the Project?](/contributing/) - _Updated Guidance Coming Soon_.

--- a/web/src/content/docs/getting-started/setup.mdx
+++ b/web/src/content/docs/getting-started/setup.mdx
@@ -57,4 +57,4 @@ In the next section, we'll create our first prompty and make use of the identifi
 
 
 ---
-[Want to Contribute To the Project?](/docs/contributing/) - _Updated Guidance Coming Soon_.
+[Want to Contribute To the Project?](/contributing/) - _Updated Guidance Coming Soon_.

--- a/web/src/content/docs/guides/extension.mdx
+++ b/web/src/content/docs/guides/extension.mdx
@@ -56,4 +56,4 @@ Hit **F5** or click the **Run** button at the top. There are two output windows:
   ![Prompty Output (Verbose)](prompty-extension/image-8.png)
 
 ---
-[Want to Contribute To the Project?](/docs/contributing/) - _Updated Guidance Coming Soon_.
+[Want to Contribute To the Project?](/contributing/) - _Updated Guidance Coming Soon_.

--- a/web/src/content/docs/guides/invoker.mdx
+++ b/web/src/content/docs/guides/invoker.mdx
@@ -27,4 +27,4 @@ Invokers trigger a call to a the different models and return its output ensuring
 TODO: Explain how invokers work and how to build a custom invoker
 
 ---
-[Want to Contribute To the Project?](/docs/contributing/) - _Updated Guidance Coming Soon_.
+[Want to Contribute To the Project?](/contributing/) - _Updated Guidance Coming Soon_.

--- a/web/src/content/docs/guides/observability.mdx
+++ b/web/src/content/docs/guides/observability.mdx
@@ -121,7 +121,7 @@ Tracer.add("OpenTelemetry", trace_span)
 This will produce spans during the execution of the prompt that can be sent to an OpenTelemetry collector for further analysis.
 
 
-To get started with Observability at refer [debugging Prompty](/docs/getting-started/debugging-prompty) in the Getting Started section.
+To get started with Observability at refer [debugging Prompty](/getting-started/debugging-prompty/) in the Getting Started section.
 
 
 ---

--- a/web/src/content/docs/guides/observability.mdx
+++ b/web/src/content/docs/guides/observability.mdx
@@ -125,4 +125,4 @@ To get started with Observability at refer [debugging Prompty](/docs/getting-sta
 
 
 ---
-[Want to Contribute To the Project?](/docs/contributing/) - _Updated Guidance Coming Soon_.
+[Want to Contribute To the Project?](/contributing/) - _Updated Guidance Coming Soon_.

--- a/web/src/content/docs/guides/prompty-runtime.mdx
+++ b/web/src/content/docs/guides/prompty-runtime.mdx
@@ -32,4 +32,4 @@ print(response)
 ```
 
 ---
-[Want to Contribute To the Project?](/docs/contributing/) - _Updated Guidance Coming Soon_.
+[Want to Contribute To the Project?](/contributing/) - _Updated Guidance Coming Soon_.

--- a/web/src/content/docs/specification/page.mdx
+++ b/web/src/content/docs/specification/page.mdx
@@ -186,7 +186,7 @@ Common parameters that can be configured for model execution:
     <tr>
       <td><code>max_tokens</code></td>
       <td>integer</td>
-      <td>The maximum number of [tokens](/tokenizer) that can be generated in the chat completion. </td>   
+      <td>The maximum number of tokens that can be generated in the chat completion. </td>   
     </tr>
     <tr>
       <td><code>temperature</code></td>

--- a/web/src/content/docs/specification/page.mdx
+++ b/web/src/content/docs/specification/page.mdx
@@ -264,4 +264,4 @@ user:
 ```
 
 ---
-[Want to Contribute To the Project?](/docs/contributing/)
+[Want to Contribute To the Project?](/contributing/)

--- a/web/src/content/docs/tutorials/using-langchain.mdx
+++ b/web/src/content/docs/tutorials/using-langchain.mdx
@@ -201,7 +201,7 @@ _Compare the code to the previous version_ - do you see the changes that help yo
 
 ## Using: VS Code Extension
 
-The Prompty Visual Studio Code extension helps you manage the creation and execution of Prompty assets within your IDE, helping speed up the inner loop for your development workflow. Read the [Prompty Extension Guide](/docs/guides/prompty-extension) for a more detailed explainer on how the create your first prompty.
+The Prompty Visual Studio Code extension helps you manage the creation and execution of Prompty assets within your IDE, helping speed up the inner loop for your development workflow. Read the [Prompty Extension Guide](/guides/extension/) for a more detailed explainer on how the create your first prompty.
 
 In _this_ section, we'll focus on using the extension to convert the `.prompty` file to Langchain code, and get a running application out of the box, for customization later.
 

--- a/web/src/content/docs/tutorials/using-langchain.mdx
+++ b/web/src/content/docs/tutorials/using-langchain.mdx
@@ -343,4 +343,4 @@ Congratulations! You just learned how to use Prompty with LangChain to orchestra
 
 
 ---
-[Want to Contribute To the Project?](/docs/contributing/) - _Updated Guidance Coming Soon_.
+[Want to Contribute To the Project?](/contributing/) - _Updated Guidance Coming Soon_.

--- a/web/src/content/docs/tutorials/using-semantic-kernel.mdx
+++ b/web/src/content/docs/tutorials/using-semantic-kernel.mdx
@@ -248,4 +248,4 @@ public class PromptyExample
 Prompty allows you to define detailed, reusable prompt templates for use in the Semantic Kernel. By following the steps in this guide, you can quickly integrate Prompty files into your Semantic Kernel-based applications, making your AI-powered interactions more dynamic and flexible.
 
 ---
-[Want to Contribute To the Project?](/docs/contributing/) - _Updated Guidance Coming Soon_.
+[Want to Contribute To the Project?](/contributing/) - _Updated Guidance Coming Soon_.

--- a/web/src/content/docs/welcome.mdx
+++ b/web/src/content/docs/welcome.mdx
@@ -52,7 +52,7 @@ This is a curated set of Azure AI Templates for use with the Azure Developer CLI
 
 ## Next Steps
 
-Start with the **[Getting Started](/docs/getting-started)** section to validate your development setup and build your first Prompty sample.
+Start with the **[Getting Started](/getting-started/)** section to validate your development setup and build your first Prompty sample.
 
 ---
 [Want to Contribute To the Project?](/contributing/) - _Updated Guidance Coming Soon_.

--- a/web/src/content/docs/welcome.mdx
+++ b/web/src/content/docs/welcome.mdx
@@ -55,4 +55,4 @@ This is a curated set of Azure AI Templates for use with the Azure Developer CLI
 Start with the **[Getting Started](/docs/getting-started)** section to validate your development setup and build your first Prompty sample.
 
 ---
-[Want to Contribute To the Project?](/docs/contributing/) - _Updated Guidance Coming Soon_.
+[Want to Contribute To the Project?](/contributing/) - _Updated Guidance Coming Soon_.


### PR DESCRIPTION
Improve link validation in the project by adding the starlight-links-validator.

Fix all broken links detected by starlight-links-validator. 

Update local server URL in the documentation guidelines.

Remove tutorial page links. There is no index page for the tutorials section.

The starlight-links-validator plugin is configured to throw an error when a broken link is detected. This behavior is configurable ([Documentation](https://starlight-links-validator.vercel.app/configuration))

The validation is made during the build phase, not with the `astro dev` command.