### PR TITLE
fix: remove slug override on reference index to fix /reference/ links

### DIFF
--- a/web/src/content/docs/reference/index.md
+++ b/web/src/content/docs/reference/index.md
@@ -1,7 +1,6 @@
 ---
 title: "AgentSchema"
 description: "Overview of declarative agent types in AgentSchema."
-slug: "reference/index"
 sidebar:
   order: 1
 ---


### PR DESCRIPTION
The \slug: 'reference/index'\ override in \eference/index.md\ caused the page to be routed to \/reference/index/\ instead of \/reference/\, breaking 7 links across the site and preventing the docs deploy from succeeding.