### PR TITLE
Prepare Rust crates for cargo publish (2.0.0-alpha.8)

### DIFF
--- a/.github/workflows/prompty-rust-check.yml
+++ b/.github/workflows/prompty-rust-check.yml
@@ -1,0 +1,48 @@
+name: prompty Rust build and test
+on:
+  pull_request:
+    paths:
+      - 'runtime/rust/**'
+
+  workflow_call:
+
+jobs:
+  rust-tests:
+    name: test rust on ${{ matrix.os }}
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu-latest, windows-latest]
+    permissions:
+      contents: read
+    defaults:
+      run:
+        working-directory: runtime/rust
+    steps:
+      - uses: actions/checkout@v5
+
+      - name: Install Rust toolchain
+        uses: dtolnay/rust-toolchain@stable
+
+      - name: Cache cargo registry & build
+        uses: actions/cache@v4
+        with:
+          path: |
+            ~/.cargo/registry
+            ~/.cargo/git
+            runtime/rust/target
+          key: ${{ runner.os }}-cargo-${{ hashFiles('runtime/rust/Cargo.lock') }}
+          restore-keys: ${{ runner.os }}-cargo-
+
+      - name: Build workspace
+        run: cargo build --workspace
+
+      - name: Run tests
+        run: cargo test --workspace
+
+      - name: Check formatting
+        run: cargo fmt --all -- --check
+
+      - name: Clippy lints
+        run: cargo clippy --workspace -- -D warnings

--- a/.github/workflows/prompty-rust.yml
+++ b/.github/workflows/prompty-rust.yml
@@ -1,0 +1,81 @@
+name: prompty Rust build and publish
+
+on:
+  push:
+    tags:
+      - 'rust/*'
+  workflow_dispatch:
+
+jobs:
+  test:
+    uses: ./.github/workflows/prompty-rust-check.yml
+
+  publish:
+    name: publish to crates.io
+    runs-on: ubuntu-latest
+    needs: test
+    if: startsWith(github.ref, 'refs/tags/rust/')
+    permissions:
+      contents: read
+    defaults:
+      run:
+        working-directory: runtime/rust
+    steps:
+      - uses: actions/checkout@v5
+
+      - name: Install Rust toolchain
+        uses: dtolnay/rust-toolchain@stable
+
+      - name: Extract version from tag
+        run: |
+          VERSION="${GITHUB_REF_NAME#rust/}"
+          echo "VERSION=$VERSION" >> "$GITHUB_ENV"
+          echo "Publishing version: $VERSION"
+
+      - name: Rewrite crate versions
+        run: |
+          # Update package versions in all crates
+          for toml in prompty/Cargo.toml prompty-openai/Cargo.toml prompty-anthropic/Cargo.toml prompty-foundry/Cargo.toml; do
+            sed -i "0,/^version = .*/s//version = \"$VERSION\"/" "$toml"
+            echo "=== $toml ==="
+            head -5 "$toml"
+          done
+
+          # Update dependency versions (prompty = { version = "...", path = "..." })
+          for toml in prompty-openai/Cargo.toml prompty-anthropic/Cargo.toml prompty-foundry/Cargo.toml; do
+            sed -i "s/prompty = { version = \"[^\"]*\"/prompty = { version = \"$VERSION\"/" "$toml"
+            sed -i "s/prompty-openai = { version = \"[^\"]*\"/prompty-openai = { version = \"$VERSION\"/" "$toml"
+          done
+
+          # Regenerate lockfile with new versions
+          cargo generate-lockfile
+
+      - name: Verify build
+        run: cargo build --workspace
+
+      # Publish in dependency order — each crate must be available before its dependents
+      - name: Publish prompty (core)
+        run: cargo publish -p prompty
+        env:
+          CARGO_REGISTRY_TOKEN: ${{ secrets.CARGO_REGISTRY_TOKEN }}
+
+      - name: Wait for crates.io index
+        run: sleep 30
+
+      - name: Publish prompty-openai
+        run: cargo publish -p prompty-openai
+        env:
+          CARGO_REGISTRY_TOKEN: ${{ secrets.CARGO_REGISTRY_TOKEN }}
+
+      - name: Wait for crates.io index
+        run: sleep 30
+
+      - name: Publish prompty-anthropic
+        run: cargo publish -p prompty-anthropic
+        env:
+          CARGO_REGISTRY_TOKEN: ${{ secrets.CARGO_REGISTRY_TOKEN }}
+
+      - name: Publish prompty-foundry
+        run: cargo publish -p prompty-foundry
+        env:
+          CARGO_REGISTRY_TOKEN: ${{ secrets.CARGO_REGISTRY_TOKEN }}

--- a/runtime/rust/Cargo.lock
+++ b/runtime/rust/Cargo.lock
@@ -1238,7 +1238,7 @@ dependencies = [
 
 [[package]]
 name = "prompty"
-version = "0.1.0"
+version = "2.0.0-alpha.8"
 dependencies = [
  "async-trait",
  "chrono",
@@ -1260,7 +1260,7 @@ dependencies = [
 
 [[package]]
 name = "prompty-anthropic"
-version = "0.1.0"
+version = "2.0.0-alpha.8"
 dependencies = [
  "async-trait",
  "bytes",
@@ -1275,7 +1275,7 @@ dependencies = [
 
 [[package]]
 name = "prompty-foundry"
-version = "0.1.0"
+version = "2.0.0-alpha.8"
 dependencies = [
  "async-trait",
  "azure_core",
@@ -1293,7 +1293,7 @@ dependencies = [
 
 [[package]]
 name = "prompty-openai"
-version = "0.1.0"
+version = "2.0.0-alpha.8"
 dependencies = [
  "async-trait",
  "bytes",

--- a/runtime/rust/Cargo.lock
+++ b/runtime/rust/Cargo.lock
@@ -1253,6 +1253,7 @@ dependencies = [
  "serde",
  "serde_json",
  "serde_yaml",
+ "serial_test",
  "thiserror 2.0.18",
  "tokio",
 ]
@@ -1268,6 +1269,7 @@ dependencies = [
  "reqwest",
  "serde",
  "serde_json",
+ "serial_test",
  "tokio",
 ]
 
@@ -1285,6 +1287,7 @@ dependencies = [
  "reqwest",
  "serde",
  "serde_json",
+ "serial_test",
  "tokio",
 ]
 
@@ -1299,6 +1302,7 @@ dependencies = [
  "reqwest",
  "serde",
  "serde_json",
+ "serial_test",
  "tokio",
 ]
 
@@ -1558,6 +1562,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9774ba4a74de5f7b1c1451ed6cd5285a32eddb5cccb8cc655a4e50009e06477f"
 
 [[package]]
+name = "scc"
+version = "2.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "46e6f046b7fef48e2660c57ed794263155d713de679057f2d0c169bfc6e756cc"
+dependencies = [
+ "sdd",
+]
+
+[[package]]
 name = "schannel"
 version = "0.1.29"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1571,6 +1584,12 @@ name = "scopeguard"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
+
+[[package]]
+name = "sdd"
+version = "3.0.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "490dcfcbfef26be6800d11870ff2df8774fa6e86d047e3e8c8a76b25655e41ca"
 
 [[package]]
 name = "security-framework"
@@ -1678,6 +1697,32 @@ dependencies = [
  "ryu",
  "serde",
  "unsafe-libyaml",
+]
+
+[[package]]
+name = "serial_test"
+version = "3.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "911bd979bf1070a3f3aa7b691a3b3e9968f339ceeec89e08c280a8a22207a32f"
+dependencies = [
+ "futures-executor",
+ "futures-util",
+ "log",
+ "once_cell",
+ "parking_lot",
+ "scc",
+ "serial_test_derive",
+]
+
+[[package]]
+name = "serial_test_derive"
+version = "3.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0a7d91949b85b0d2fb687445e448b40d322b6b3e4af6b44a29b21d9a5f33e6d9"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]
@@ -1806,7 +1851,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32497e9a4c7b38532efcdebeef879707aa9f794296a4f0244f6f69e9bc8574bd"
 dependencies = [
  "fastrand",
- "getrandom 0.3.4",
+ "getrandom 0.4.2",
  "once_cell",
  "rustix",
  "windows-sys 0.61.2",

--- a/runtime/rust/prompty-anthropic/Cargo.toml
+++ b/runtime/rust/prompty-anthropic/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "prompty-anthropic"
-version = "0.1.0"
+version = "2.0.0-alpha.8"
 edition = "2024"
 rust-version = "1.85"
 description = "Anthropic provider for Prompty — Claude Messages API executor and processor"
@@ -12,7 +12,7 @@ keywords = ["llm", "prompt", "anthropic", "claude", "ai"]
 categories = ["development-tools"]
 
 [dependencies]
-prompty = { version = "0.1.0", path = "../prompty" }
+prompty = { version = "2.0.0-alpha.8", path = "../prompty" }
 async-trait = "0.1"
 bytes = "1"
 futures = "0.3"

--- a/runtime/rust/prompty-anthropic/Cargo.toml
+++ b/runtime/rust/prompty-anthropic/Cargo.toml
@@ -5,9 +5,14 @@ edition = "2024"
 rust-version = "1.85"
 description = "Anthropic provider for Prompty — Claude Messages API executor and processor"
 license = "MIT"
+repository = "https://github.com/microsoft/prompty"
+documentation = "https://docs.rs/prompty-anthropic"
+readme = "README.md"
+keywords = ["llm", "prompt", "anthropic", "claude", "ai"]
+categories = ["development-tools"]
 
 [dependencies]
-prompty = { path = "../prompty" }
+prompty = { version = "0.1.0", path = "../prompty" }
 async-trait = "0.1"
 bytes = "1"
 futures = "0.3"
@@ -15,3 +20,6 @@ reqwest = { version = "0.12", features = ["json", "stream"] }
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 tokio = { version = "1", features = ["full"] }
+
+[dev-dependencies]
+serial_test = "3"

--- a/runtime/rust/prompty-anthropic/LICENSE
+++ b/runtime/rust/prompty-anthropic/LICENSE
@@ -1,0 +1,21 @@
+    MIT License
+
+    Copyright (c) Microsoft Corporation.
+
+    Permission is hereby granted, free of charge, to any person obtaining a copy
+    of this software and associated documentation files (the "Software"), to deal
+    in the Software without restriction, including without limitation the rights
+    to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+    copies of the Software, and to permit persons to whom the Software is
+    furnished to do so, subject to the following conditions:
+
+    The above copyright notice and this permission notice shall be included in all
+    copies or substantial portions of the Software.
+
+    THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+    IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+    FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+    AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+    LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+    OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+    SOFTWARE

--- a/runtime/rust/prompty-anthropic/README.md
+++ b/runtime/rust/prompty-anthropic/README.md
@@ -1,0 +1,33 @@
+# prompty-anthropic
+
+Anthropic Claude provider for [**prompty**](https://crates.io/crates/prompty) — adds executor and processor implementations for the Claude Messages API.
+
+## Usage
+
+```rust
+use prompty::{load, turn, register_defaults};
+
+// Register built-in renderers/parsers + Anthropic provider
+register_defaults();
+prompty_anthropic::register();
+
+let agent = load("chat.prompty").await?;
+let result = turn(&agent, Some(&inputs), None).await?;
+```
+
+## Connection
+
+Configure via `.prompty` frontmatter or environment variables:
+
+```yaml
+model:
+  id: claude-sonnet-4-20250514
+  provider: anthropic
+  connection:
+    kind: key
+    apiKey: ${env:ANTHROPIC_API_KEY}
+```
+
+## License
+
+MIT — see [LICENSE](LICENSE) for details.

--- a/runtime/rust/prompty-anthropic/src/executor.rs
+++ b/runtime/rust/prompty-anthropic/src/executor.rs
@@ -373,6 +373,7 @@ mod tests {
     }
 
     #[test]
+    #[serial]
     fn test_build_url_default() {
         let agent = make_agent(json!({"id": "claude-3", "provider": "anthropic"}));
         let url = build_url(&agent).unwrap();
@@ -380,6 +381,7 @@ mod tests {
     }
 
     #[test]
+    #[serial]
     fn test_build_url_custom_endpoint() {
         let agent = make_agent(json!({
             "id": "claude-3",
@@ -395,6 +397,7 @@ mod tests {
     }
 
     #[test]
+    #[serial]
     fn test_get_api_key_from_connection() {
         let agent = make_agent(json!({
             "id": "claude-3",
@@ -409,6 +412,7 @@ mod tests {
     }
 
     #[test]
+    #[serial]
     fn test_build_args_chat() {
         let agent = make_agent(json!({
             "id": "claude-3",
@@ -423,6 +427,7 @@ mod tests {
     }
 
     #[test]
+    #[serial]
     fn test_build_args_rejects_embedding() {
         let agent = make_agent(json!({
             "id": "claude-3",
@@ -437,6 +442,7 @@ mod tests {
     // --- Reference connection resolution tests ---
 
     #[test]
+    #[serial]
     fn test_resolve_connection_passthrough() {
         let agent = make_agent(json!({
             "id": "claude-3",
@@ -451,6 +457,7 @@ mod tests {
     }
 
     #[test]
+    #[serial]
     fn test_resolve_connection_reference_missing_name() {
         let agent = make_agent(json!({
             "id": "claude-3",

--- a/runtime/rust/prompty-anthropic/src/executor.rs
+++ b/runtime/rust/prompty-anthropic/src/executor.rs
@@ -359,6 +359,7 @@ mod tests {
     use super::*;
     use prompty::model::Prompty;
     use prompty::model::context::LoadContext;
+    use serial_test::serial;
     use serde_json::json;
 
     fn make_agent(model_json: Value) -> Prompty {
@@ -462,6 +463,7 @@ mod tests {
     }
 
     #[test]
+    #[serial]
     fn test_resolve_connection_reference_success() {
         prompty::connections::clear_connections();
         prompty::connections::register_connection(
@@ -487,6 +489,7 @@ mod tests {
     }
 
     #[test]
+    #[serial]
     fn test_reference_connection_flows_to_api_key() {
         prompty::connections::clear_connections();
         prompty::connections::register_connection(
@@ -510,6 +513,7 @@ mod tests {
     }
 
     #[test]
+    #[serial]
     fn test_reference_connection_flows_to_build_url() {
         prompty::connections::clear_connections();
         prompty::connections::register_connection(

--- a/runtime/rust/prompty-foundry/Cargo.toml
+++ b/runtime/rust/prompty-foundry/Cargo.toml
@@ -5,10 +5,15 @@ edition = "2024"
 rust-version = "1.85"
 description = "Azure OpenAI / Foundry provider for Prompty"
 license = "MIT"
+repository = "https://github.com/microsoft/prompty"
+documentation = "https://docs.rs/prompty-foundry"
+readme = "README.md"
+keywords = ["llm", "prompt", "azure", "openai", "foundry"]
+categories = ["development-tools"]
 
 [dependencies]
-prompty = { path = "../prompty" }
-prompty-openai = { path = "../prompty-openai" }
+prompty = { version = "0.1.0", path = "../prompty" }
+prompty-openai = { version = "0.1.0", path = "../prompty-openai" }
 async-trait = "0.1"
 azure_identity = { version = "0.23", optional = true }
 azure_core = { version = "0.23", optional = true }
@@ -25,3 +30,4 @@ entra_id = ["azure_identity", "azure_core"]
 
 [dev-dependencies]
 tokio = { version = "1", features = ["full", "test-util"] }
+serial_test = "3"

--- a/runtime/rust/prompty-foundry/Cargo.toml
+++ b/runtime/rust/prompty-foundry/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "prompty-foundry"
-version = "0.1.0"
+version = "2.0.0-alpha.8"
 edition = "2024"
 rust-version = "1.85"
 description = "Azure OpenAI / Foundry provider for Prompty"
@@ -12,8 +12,8 @@ keywords = ["llm", "prompt", "azure", "openai", "foundry"]
 categories = ["development-tools"]
 
 [dependencies]
-prompty = { version = "0.1.0", path = "../prompty" }
-prompty-openai = { version = "0.1.0", path = "../prompty-openai" }
+prompty = { version = "2.0.0-alpha.8", path = "../prompty" }
+prompty-openai = { version = "2.0.0-alpha.8", path = "../prompty-openai" }
 async-trait = "0.1"
 azure_identity = { version = "0.23", optional = true }
 azure_core = { version = "0.23", optional = true }

--- a/runtime/rust/prompty-foundry/LICENSE
+++ b/runtime/rust/prompty-foundry/LICENSE
@@ -1,0 +1,21 @@
+    MIT License
+
+    Copyright (c) Microsoft Corporation.
+
+    Permission is hereby granted, free of charge, to any person obtaining a copy
+    of this software and associated documentation files (the "Software"), to deal
+    in the Software without restriction, including without limitation the rights
+    to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+    copies of the Software, and to permit persons to whom the Software is
+    furnished to do so, subject to the following conditions:
+
+    The above copyright notice and this permission notice shall be included in all
+    copies or substantial portions of the Software.
+
+    THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+    IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+    FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+    AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+    LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+    OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+    SOFTWARE

--- a/runtime/rust/prompty-foundry/README.md
+++ b/runtime/rust/prompty-foundry/README.md
@@ -1,0 +1,38 @@
+# prompty-foundry
+
+Azure OpenAI / Foundry provider for [**prompty**](https://crates.io/crates/prompty) — adds executor and processor implementations for Azure-hosted OpenAI models.
+
+## Usage
+
+```rust
+use prompty::{load, turn, register_defaults};
+
+// Register built-in renderers/parsers + Azure/Foundry provider
+register_defaults();
+prompty_foundry::register();
+
+let agent = load("chat.prompty").await?;
+let result = turn(&agent, Some(&inputs), None).await?;
+```
+
+## Connection
+
+Configure via `.prompty` frontmatter or environment variables:
+
+```yaml
+model:
+  id: gpt-4o
+  provider: foundry
+  connection:
+    kind: key
+    endpoint: ${env:AZURE_OPENAI_ENDPOINT}
+    apiKey: ${env:AZURE_OPENAI_API_KEY}
+```
+
+## Features
+
+- `entra_id` — Enables Microsoft Entra ID (Azure AD) authentication via `azure_identity`
+
+## License
+
+MIT — see [LICENSE](LICENSE) for details.

--- a/runtime/rust/prompty-foundry/src/executor.rs
+++ b/runtime/rust/prompty-foundry/src/executor.rs
@@ -469,6 +469,7 @@ mod tests {
     }
 
     #[tokio::test]
+    #[serial]
     async fn test_build_url_api_key_connection() {
         let agent = make_agent(json!({
             "id": "gpt-4",
@@ -484,6 +485,7 @@ mod tests {
     }
 
     #[tokio::test]
+    #[serial]
     async fn test_build_url_foundry_connection() {
         // Foundry connections typically use Entra ID, but for testing we
         // supply an API key via env var since Entra ID may not be enabled
@@ -504,6 +506,7 @@ mod tests {
     }
 
     #[tokio::test]
+    #[serial]
     async fn test_build_url_embedding() {
         let agent = make_agent(json!({
             "id": "text-embedding-3-small",
@@ -518,6 +521,7 @@ mod tests {
     }
 
     #[tokio::test]
+    #[serial]
     async fn test_build_url_image() {
         let agent = make_agent(json!({
             "id": "dall-e-3",
@@ -532,6 +536,7 @@ mod tests {
     }
 
     #[tokio::test]
+    #[serial]
     async fn test_auth_header_api_key() {
         let agent = make_agent(json!({
             "id": "gpt-4",
@@ -547,6 +552,7 @@ mod tests {
     }
 
     #[test]
+    #[serial]
     fn test_strip_project_path() {
         assert_eq!(
             strip_project_path("https://myresource.services.ai.azure.com/api/projects/my-project"),
@@ -559,6 +565,7 @@ mod tests {
     }
 
     #[test]
+    #[serial]
     fn test_deployment_from_model_id() {
         let agent = make_agent(json!({
             "id": "my-deployment-name",
@@ -573,6 +580,7 @@ mod tests {
     }
 
     #[test]
+    #[serial]
     fn test_api_version_default() {
         let agent = make_agent(json!({
             "id": "gpt-4",
@@ -587,6 +595,7 @@ mod tests {
     }
 
     #[tokio::test]
+    #[serial]
     async fn test_unsupported_api_type() {
         let agent = make_agent(json!({
             "id": "gpt-4",
@@ -603,6 +612,7 @@ mod tests {
     // --- Reference connection resolution tests ---
 
     #[test]
+    #[serial]
     fn test_resolve_connection_passthrough() {
         let agent = make_agent(json!({
             "id": "gpt-4",
@@ -618,6 +628,7 @@ mod tests {
     }
 
     #[test]
+    #[serial]
     fn test_resolve_connection_reference_missing_name() {
         let agent = make_agent(json!({
             "id": "gpt-4",

--- a/runtime/rust/prompty-foundry/src/executor.rs
+++ b/runtime/rust/prompty-foundry/src/executor.rs
@@ -455,6 +455,7 @@ impl Stream for FoundrySseParser {
 mod tests {
     use super::*;
     use prompty::model::context::LoadContext;
+    use serial_test::serial;
     use serde_json::json;
 
     fn make_agent(model_json: Value) -> Prompty {
@@ -628,6 +629,7 @@ mod tests {
     }
 
     #[test]
+    #[serial]
     fn test_resolve_connection_reference_success() {
         prompty::connections::clear_connections();
         prompty::connections::register_connection(
@@ -652,6 +654,7 @@ mod tests {
     }
 
     #[tokio::test]
+    #[serial]
     async fn test_reference_connection_flows_to_auth_header() {
         prompty::connections::clear_connections();
         prompty::connections::register_connection(
@@ -678,6 +681,7 @@ mod tests {
     // --- Entra ID stub test ---
 
     #[tokio::test]
+    #[serial]
     async fn test_auth_header_foundry_no_key_no_entra() {
         prompty::connections::clear_connections();
         // Remove env var to ensure no fallback

--- a/runtime/rust/prompty-openai/Cargo.toml
+++ b/runtime/rust/prompty-openai/Cargo.toml
@@ -5,9 +5,14 @@ edition = "2024"
 rust-version = "1.85"
 description = "OpenAI provider for Prompty"
 license = "MIT"
+repository = "https://github.com/microsoft/prompty"
+documentation = "https://docs.rs/prompty-openai"
+readme = "README.md"
+keywords = ["llm", "prompt", "openai", "ai"]
+categories = ["development-tools"]
 
 [dependencies]
-prompty = { path = "../prompty" }
+prompty = { version = "0.1.0", path = "../prompty" }
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 async-trait = "0.1"
@@ -18,3 +23,4 @@ bytes = "1"
 
 [dev-dependencies]
 tokio = { version = "1", features = ["full"] }
+serial_test = "3"

--- a/runtime/rust/prompty-openai/Cargo.toml
+++ b/runtime/rust/prompty-openai/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "prompty-openai"
-version = "0.1.0"
+version = "2.0.0-alpha.8"
 edition = "2024"
 rust-version = "1.85"
 description = "OpenAI provider for Prompty"
@@ -12,7 +12,7 @@ keywords = ["llm", "prompt", "openai", "ai"]
 categories = ["development-tools"]
 
 [dependencies]
-prompty = { version = "0.1.0", path = "../prompty" }
+prompty = { version = "2.0.0-alpha.8", path = "../prompty" }
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 async-trait = "0.1"

--- a/runtime/rust/prompty-openai/LICENSE
+++ b/runtime/rust/prompty-openai/LICENSE
@@ -1,0 +1,21 @@
+    MIT License
+
+    Copyright (c) Microsoft Corporation.
+
+    Permission is hereby granted, free of charge, to any person obtaining a copy
+    of this software and associated documentation files (the "Software"), to deal
+    in the Software without restriction, including without limitation the rights
+    to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+    copies of the Software, and to permit persons to whom the Software is
+    furnished to do so, subject to the following conditions:
+
+    The above copyright notice and this permission notice shall be included in all
+    copies or substantial portions of the Software.
+
+    THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+    IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+    FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+    AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+    LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+    OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+    SOFTWARE

--- a/runtime/rust/prompty-openai/README.md
+++ b/runtime/rust/prompty-openai/README.md
@@ -1,0 +1,41 @@
+# prompty-openai
+
+OpenAI provider for [**prompty**](https://crates.io/crates/prompty) — adds executor and processor implementations for the OpenAI Chat Completions, Embeddings, and Images APIs.
+
+## Usage
+
+```rust
+use prompty::{load, turn, register_defaults};
+
+// Register built-in renderers/parsers + OpenAI provider
+register_defaults();
+prompty_openai::register();
+
+let agent = load("chat.prompty").await?;
+let result = turn(&agent, Some(&inputs), None).await?;
+```
+
+## Supported API Types
+
+| `apiType` | API | Description |
+|-----------|-----|-------------|
+| `chat` | Chat Completions | Text generation and tool calling |
+| `embedding` | Embeddings | Vector embeddings |
+| `image` | Images | DALL-E image generation |
+
+## Connection
+
+Configure via `.prompty` frontmatter or environment variables:
+
+```yaml
+model:
+  id: gpt-4o
+  provider: openai
+  connection:
+    kind: key
+    apiKey: ${env:OPENAI_API_KEY}
+```
+
+## License
+
+MIT — see [LICENSE](LICENSE) for details.

--- a/runtime/rust/prompty-openai/src/executor.rs
+++ b/runtime/rust/prompty-openai/src/executor.rs
@@ -406,6 +406,7 @@ mod tests {
     }
 
     #[test]
+    #[serial]
     fn test_build_url_default() {
         let agent = make_agent(json!({"id": "gpt-4"}));
         let url = build_url(&agent, "/v1/chat/completions").unwrap();
@@ -413,6 +414,7 @@ mod tests {
     }
 
     #[test]
+    #[serial]
     fn test_build_url_custom_endpoint() {
         let agent = make_agent(json!({
             "id": "gpt-4",
@@ -427,6 +429,7 @@ mod tests {
     }
 
     #[test]
+    #[serial]
     fn test_get_api_key_from_connection() {
         let agent = make_agent(json!({
             "id": "gpt-4",
@@ -441,6 +444,7 @@ mod tests {
     }
 
     #[test]
+    #[serial]
     fn test_build_args_chat() {
         let agent = make_agent(json!({"id": "gpt-4", "apiType": "chat"}));
         let messages = vec![Message::text(prompty::Role::User, "Hello")];
@@ -450,6 +454,7 @@ mod tests {
     }
 
     #[test]
+    #[serial]
     fn test_build_args_embedding() {
         let agent = make_agent(json!({"id": "text-embedding-3-small", "apiType": "embedding"}));
         let messages = vec![Message::text(prompty::Role::User, "Hello world")];
@@ -459,6 +464,7 @@ mod tests {
     }
 
     #[tokio::test]
+    #[serial]
     async fn test_sse_parser_basic() {
         use futures::StreamExt;
 
@@ -479,6 +485,7 @@ mod tests {
     }
 
     #[tokio::test]
+    #[serial]
     async fn test_sse_parser_multi_chunk() {
         use futures::StreamExt;
 
@@ -499,6 +506,7 @@ mod tests {
     // --- Reference connection resolution tests ---
 
     #[test]
+    #[serial]
     fn test_resolve_connection_passthrough_key() {
         // Non-reference connections should pass through unchanged
         let agent = make_agent(json!({
@@ -515,6 +523,7 @@ mod tests {
     }
 
     #[test]
+    #[serial]
     fn test_resolve_connection_reference_missing_name() {
         let agent = make_agent(json!({
             "id": "gpt-4",

--- a/runtime/rust/prompty-openai/src/executor.rs
+++ b/runtime/rust/prompty-openai/src/executor.rs
@@ -392,6 +392,7 @@ mod tests {
     use super::*;
     use prompty::model::Prompty;
     use prompty::model::context::LoadContext;
+    use serial_test::serial;
     use serde_json::json;
 
     fn make_agent(model_json: Value) -> Prompty {
@@ -528,6 +529,7 @@ mod tests {
     }
 
     #[test]
+    #[serial]
     fn test_resolve_connection_reference_not_registered() {
         prompty::connections::clear_connections();
         let agent = make_agent(json!({
@@ -543,6 +545,7 @@ mod tests {
     }
 
     #[test]
+    #[serial]
     fn test_resolve_connection_reference_success() {
         prompty::connections::clear_connections();
         // Register a connection as a JSON Value
@@ -572,6 +575,7 @@ mod tests {
     }
 
     #[test]
+    #[serial]
     fn test_reference_connection_flows_to_build_url() {
         prompty::connections::clear_connections();
         prompty::connections::register_connection(

--- a/runtime/rust/prompty-openai/src/wire.rs
+++ b/runtime/rust/prompty-openai/src/wire.rs
@@ -331,30 +331,29 @@ fn property_to_json_schema(prop: &Property) -> Value {
                 let ctx = prompty::model::context::LoadContext::default();
                 let item_prop = Property::load_from_value(items, &ctx);
                 schema.insert("items".to_string(), property_to_json_schema(&item_prop));
-            } else {
-                schema.insert("items".to_string(), json!({"type": "string"}));
             }
+            // When items is null/unspecified, emit bare {"type": "array"}
         }
         PropertyKind::Object { properties } => {
             if let Some(arr) = properties.as_array() {
-                let ctx = prompty::model::context::LoadContext::default();
-                let mut nested = Map::new();
-                let mut req = Vec::new();
-                for val in arr {
-                    let p = Property::load_from_value(val, &ctx);
-                    if p.name.is_empty() {
-                        continue;
+                if !arr.is_empty() {
+                    let ctx = prompty::model::context::LoadContext::default();
+                    let mut nested = Map::new();
+                    let mut req = Vec::new();
+                    for val in arr {
+                        let p = Property::load_from_value(val, &ctx);
+                        if p.name.is_empty() {
+                            continue;
+                        }
+                        nested.insert(p.name.clone(), property_to_json_schema(&p));
+                        req.push(Value::String(p.name.clone()));
                     }
-                    nested.insert(p.name.clone(), property_to_json_schema(&p));
-                    req.push(Value::String(p.name.clone()));
+                    schema.insert("properties".to_string(), Value::Object(nested));
+                    schema.insert("required".to_string(), Value::Array(req));
+                    schema.insert("additionalProperties".to_string(), Value::Bool(false));
                 }
-                schema.insert("properties".to_string(), Value::Object(nested));
-                schema.insert("required".to_string(), Value::Array(req));
-            } else {
-                schema.insert("properties".to_string(), json!({}));
-                schema.insert("required".to_string(), json!([]));
             }
-            schema.insert("additionalProperties".to_string(), Value::Bool(false));
+            // When properties is empty or absent, emit bare {"type": "object"}
         }
         _ => {}
     }

--- a/runtime/rust/prompty/Cargo.toml
+++ b/runtime/rust/prompty/Cargo.toml
@@ -5,6 +5,11 @@ edition = "2024"
 rust-version = "1.85"
 description = "Prompty is an asset class and format for LLM prompts"
 license = "MIT"
+repository = "https://github.com/microsoft/prompty"
+documentation = "https://docs.rs/prompty"
+readme = "README.md"
+keywords = ["llm", "prompt", "ai", "template", "agent"]
+categories = ["development-tools", "text-processing"]
 
 [dependencies]
 serde = { version = "1", features = ["derive"] }
@@ -12,7 +17,7 @@ serde_json = "1"
 serde_yaml = "0.9"
 thiserror = "2"
 async-trait = "0.1"
-tokio = { version = "1", features = ["sync", "fs"] }
+tokio = { version = "1", features = ["sync", "fs", "rt"] }
 minijinja = "2"
 rand = "0.9"
 regex = "1"
@@ -31,3 +36,4 @@ otel = ["opentelemetry", "opentelemetry_sdk", "opentelemetry-stdout"]
 
 [dev-dependencies]
 tokio = { version = "1", features = ["full"] }
+serial_test = "3"

--- a/runtime/rust/prompty/Cargo.toml
+++ b/runtime/rust/prompty/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "prompty"
-version = "0.1.0"
+version = "2.0.0-alpha.8"
 edition = "2024"
 rust-version = "1.85"
 description = "Prompty is an asset class and format for LLM prompts"

--- a/runtime/rust/prompty/LICENSE
+++ b/runtime/rust/prompty/LICENSE
@@ -1,0 +1,21 @@
+    MIT License
+
+    Copyright (c) Microsoft Corporation.
+
+    Permission is hereby granted, free of charge, to any person obtaining a copy
+    of this software and associated documentation files (the "Software"), to deal
+    in the Software without restriction, including without limitation the rights
+    to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+    copies of the Software, and to permit persons to whom the Software is
+    furnished to do so, subject to the following conditions:
+
+    The above copyright notice and this permission notice shall be included in all
+    copies or substantial portions of the Software.
+
+    THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+    IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+    FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+    AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+    LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+    OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+    SOFTWARE

--- a/runtime/rust/prompty/README.md
+++ b/runtime/rust/prompty/README.md
@@ -1,0 +1,57 @@
+# prompty
+
+**Prompty** is a Rust runtime for the [`.prompty`](https://github.com/microsoft/prompty) file format — a markdown-based asset class for LLM prompts. YAML frontmatter defines model configuration, connection details, tools, and schemas. The markdown body becomes templated instructions.
+
+## Quick Start
+
+```rust
+use prompty::{load, prepare, run, turn, register_defaults};
+
+// Register built-in renderers and parsers
+register_defaults();
+
+// Load a .prompty file into a typed agent
+let agent = load("path/to/prompt.prompty").await?;
+
+// Render template + parse role markers → Vec<Message>
+let messages = prepare(&agent, Some(&inputs)).await?;
+
+// Execute LLM call + process response
+let result = run(&agent, &messages).await?;
+
+// Or do it all in one shot with agent loop support
+let result = turn(&agent, Some(&inputs), None).await?;
+```
+
+## Pipeline
+
+The runtime provides 5 public functions:
+
+| Function | Description |
+|----------|-------------|
+| `load()` | Parse a `.prompty` file → typed `Prompty` agent |
+| `prepare()` | Render template + parse role markers → `Vec<Message>` |
+| `run()` | Execute LLM call + process response (takes messages) |
+| `invoke_agent()` | One-shot: load → prepare → execute → process |
+| `turn()` | Conversation round with optional tool-calling agent loop |
+
+## Providers
+
+LLM providers are separate crates — register them before calling pipeline functions:
+
+- [`prompty-openai`](https://crates.io/crates/prompty-openai) — OpenAI API
+- [`prompty-foundry`](https://crates.io/crates/prompty-foundry) — Azure OpenAI / Foundry
+- [`prompty-anthropic`](https://crates.io/crates/prompty-anthropic) — Anthropic Claude
+
+```rust
+// Register OpenAI provider
+prompty_openai::register();
+```
+
+## Features
+
+- `otel` — Enables OpenTelemetry tracing backend
+
+## License
+
+MIT — see [LICENSE](LICENSE) for details.

--- a/runtime/rust/prompty/src/connections.rs
+++ b/runtime/rust/prompty/src/connections.rs
@@ -109,6 +109,7 @@ pub fn clear_connections() {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use serial_test::serial;
 
     #[derive(Debug)]
     struct FakeClient {
@@ -116,6 +117,7 @@ mod tests {
     }
 
     #[test]
+    #[serial]
     fn test_register_and_check() {
         clear_connections();
         assert!(!has_connection("test"));
@@ -129,6 +131,7 @@ mod tests {
     }
 
     #[test]
+    #[serial]
     fn test_with_connection_success() {
         clear_connections();
         register_connection(
@@ -142,6 +145,7 @@ mod tests {
     }
 
     #[test]
+    #[serial]
     fn test_with_connection_missing() {
         clear_connections();
         let result = with_connection::<FakeClient, _>("missing", |_| ());
@@ -150,6 +154,7 @@ mod tests {
     }
 
     #[test]
+    #[serial]
     fn test_with_connection_wrong_type() {
         clear_connections();
         register_connection("typed", 42_u32);
@@ -159,6 +164,7 @@ mod tests {
     }
 
     #[test]
+    #[serial]
     fn test_clear_connections() {
         register_connection("temp", 100_u32);
         assert!(has_connection("temp"));
@@ -167,6 +173,7 @@ mod tests {
     }
 
     #[test]
+    #[serial]
     fn test_overwrite_connection() {
         clear_connections();
         register_connection(

--- a/runtime/rust/prompty/src/pipeline.rs
+++ b/runtime/rust/prompty/src/pipeline.rs
@@ -1251,6 +1251,7 @@ mod tests {
     use super::*;
     use crate::model::Prompty;
     use crate::model::context::LoadContext;
+    use serial_test::serial;
 
     fn make_agent_with_inputs() -> Prompty {
         let data = serde_json::json!({
@@ -1293,6 +1294,7 @@ mod tests {
     }
 
     #[tokio::test]
+    #[serial]
     async fn test_prepare_renders_and_parses() {
         ensure_defaults();
         let agent = make_agent_with_inputs();
@@ -1306,6 +1308,7 @@ mod tests {
     }
 
     #[tokio::test]
+    #[serial]
     async fn test_prepare_with_defaults() {
         ensure_defaults();
         let agent = make_agent_with_inputs();
@@ -1691,6 +1694,7 @@ mod tests {
     }
 
     #[tokio::test]
+    #[serial]
     async fn test_turn_without_tools_invokes_directly() {
         ensure_defaults();
         let key = "turn_test_no_tools";
@@ -1706,6 +1710,7 @@ mod tests {
     }
 
     #[tokio::test]
+    #[serial]
     async fn test_turn_with_tools_single_iteration() {
         ensure_defaults();
         let key = "turn_test_single";
@@ -1730,6 +1735,7 @@ mod tests {
     }
 
     #[tokio::test]
+    #[serial]
     async fn test_turn_with_multiple_tools() {
         ensure_defaults();
         let key = "turn_test_multi";
@@ -1760,6 +1766,7 @@ mod tests {
     }
 
     #[tokio::test]
+    #[serial]
     async fn test_turn_max_iterations() {
         ensure_defaults();
         let key = "turn_test_max_iter";
@@ -1794,6 +1801,7 @@ mod tests {
     }
 
     #[tokio::test]
+    #[serial]
     async fn test_turn_cancellation_before_start() {
         ensure_defaults();
         let key = "turn_test_cancel_before";
@@ -1818,6 +1826,7 @@ mod tests {
     }
 
     #[tokio::test]
+    #[serial]
     async fn test_turn_cancellation_mid_loop() {
         ensure_defaults();
         let key = "turn_test_cancel_mid";
@@ -1859,6 +1868,7 @@ mod tests {
     }
 
     #[tokio::test]
+    #[serial]
     async fn test_turn_events_sequence() {
         ensure_defaults();
         let key = "turn_test_events";
@@ -1896,6 +1906,7 @@ mod tests {
     }
 
     #[tokio::test]
+    #[serial]
     async fn test_turn_tool_error_propagates() {
         ensure_defaults();
         let key = "turn_test_tool_err";
@@ -1919,6 +1930,7 @@ mod tests {
     }
 
     #[tokio::test]
+    #[serial]
     async fn test_turn_missing_tool_handler_error() {
         ensure_defaults();
         let key = "turn_test_missing_tool";
@@ -1961,6 +1973,7 @@ mod tests {
     // -----------------------------------------------------------------------
 
     #[tokio::test]
+    #[serial]
     async fn test_run_with_mock_executor() {
         ensure_defaults();
         let key = "run_test";
@@ -1976,6 +1989,7 @@ mod tests {
     }
 
     #[tokio::test]
+    #[serial]
     async fn test_invoke_with_mock_executor() {
         ensure_defaults();
         let key = "invoke_test";

--- a/runtime/rust/prompty/src/registry.rs
+++ b/runtime/rust/prompty/src/registry.rs
@@ -295,6 +295,7 @@ pub fn invoke_pre_render(key: &str, template: &str) -> Result<Option<(String, se
 #[cfg(test)]
 mod tests {
     use super::*;
+    use serial_test::serial;
 
     struct DummyRenderer;
     #[async_trait::async_trait]
@@ -350,6 +351,7 @@ mod tests {
     }
 
     #[test]
+    #[serial]
     fn test_register_and_get_renderer() {
         clear_cache();
         register_renderer("test", DummyRenderer);
@@ -358,6 +360,7 @@ mod tests {
     }
 
     #[test]
+    #[serial]
     fn test_register_and_get_parser() {
         clear_cache();
         register_parser("test", DummyParser);
@@ -366,6 +369,7 @@ mod tests {
     }
 
     #[test]
+    #[serial]
     fn test_register_and_get_executor() {
         clear_cache();
         register_executor("test", DummyExecutor);
@@ -374,6 +378,7 @@ mod tests {
     }
 
     #[test]
+    #[serial]
     fn test_register_and_get_processor() {
         clear_cache();
         register_processor("test", DummyProcessor);
@@ -382,6 +387,7 @@ mod tests {
     }
 
     #[test]
+    #[serial]
     fn test_clear_cache() {
         register_renderer("clear_test", DummyRenderer);
         assert!(has_renderer("clear_test"));
@@ -390,6 +396,7 @@ mod tests {
     }
 
     #[tokio::test]
+    #[serial]
     async fn test_invoke_renderer() {
         clear_cache();
         register_renderer("inv_test", DummyRenderer);
@@ -399,6 +406,7 @@ mod tests {
     }
 
     #[tokio::test]
+    #[serial]
     async fn test_invoke_missing_renderer_error() {
         clear_cache();
         let agent = crate::model::Prompty::default();
@@ -409,6 +417,7 @@ mod tests {
     }
 
     #[tokio::test]
+    #[serial]
     async fn test_invoke_parser() {
         clear_cache();
         register_parser("test_parser", DummyParser);
@@ -419,6 +428,7 @@ mod tests {
     }
 
     #[tokio::test]
+    #[serial]
     async fn test_invoke_parser_missing() {
         clear_cache();
         let agent = crate::model::Prompty::default();
@@ -428,6 +438,7 @@ mod tests {
     }
 
     #[tokio::test]
+    #[serial]
     async fn test_invoke_executor() {
         clear_cache();
         register_executor("test_exec", DummyExecutor);
@@ -437,6 +448,7 @@ mod tests {
     }
 
     #[tokio::test]
+    #[serial]
     async fn test_invoke_executor_missing() {
         clear_cache();
         let agent = crate::model::Prompty::default();
@@ -446,6 +458,7 @@ mod tests {
     }
 
     #[tokio::test]
+    #[serial]
     async fn test_invoke_processor() {
         clear_cache();
         register_processor("test_proc", DummyProcessor);
@@ -455,6 +468,7 @@ mod tests {
     }
 
     #[tokio::test]
+    #[serial]
     async fn test_invoke_processor_missing() {
         clear_cache();
         let agent = crate::model::Prompty::default();
@@ -464,6 +478,7 @@ mod tests {
     }
 
     #[test]
+    #[serial]
     fn test_invoke_format_tool_messages_default() {
         clear_cache();
         register_executor("test_ftm", DummyExecutor);
@@ -485,6 +500,7 @@ mod tests {
     }
 
     #[test]
+    #[serial]
     fn test_invoke_format_tool_messages_missing_executor() {
         clear_cache();
         let err = invoke_format_tool_messages("nope", &serde_json::json!({}), &[], &[], None).unwrap_err();
@@ -492,6 +508,7 @@ mod tests {
     }
 
     #[test]
+    #[serial]
     fn test_invoke_pre_render() {
         clear_cache();
         register_parser("test_pre", DummyParser);
@@ -501,6 +518,7 @@ mod tests {
     }
 
     #[test]
+    #[serial]
     fn test_invoke_pre_render_missing_parser() {
         clear_cache();
         let err = invoke_pre_render("nope", "template").unwrap_err();

--- a/runtime/rust/prompty/src/tool_dispatch.rs
+++ b/runtime/rust/prompty/src/tool_dispatch.rs
@@ -538,6 +538,7 @@ pub fn register_builtin_handlers() {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use serial_test::serial;
     use crate::pipeline::ToolHandler as PipelineToolHandler;
 
     fn make_tool_call(name: &str, args: &str) -> ToolCall {
@@ -559,6 +560,7 @@ mod tests {
     }
 
     #[tokio::test]
+    #[serial]
     async fn test_dispatch_user_tools_first() {
         clear_tools();
         clear_tool_handlers();
@@ -574,6 +576,7 @@ mod tests {
     }
 
     #[tokio::test]
+    #[serial]
     async fn test_dispatch_name_registry_second() {
         clear_tools();
         clear_tool_handlers();
@@ -588,6 +591,7 @@ mod tests {
     }
 
     #[tokio::test]
+    #[serial]
     async fn test_dispatch_missing_tool() {
         clear_tools();
         clear_tool_handlers();
@@ -599,6 +603,7 @@ mod tests {
     }
 
     #[tokio::test]
+    #[serial]
     async fn test_dispatch_invalid_json_args() {
         clear_tools();
         let user_tools = HashMap::new();
@@ -609,6 +614,7 @@ mod tests {
     }
 
     #[tokio::test]
+    #[serial]
     async fn test_dispatch_user_tool_error() {
         clear_tools();
         let mut user_tools = HashMap::new();
@@ -626,6 +632,7 @@ mod tests {
     }
 
     #[test]
+    #[serial]
     fn test_register_and_check_tool() {
         clear_tools();
         assert!(!has_tool("my_tool"));
@@ -634,6 +641,7 @@ mod tests {
     }
 
     #[test]
+    #[serial]
     fn test_register_and_check_handler() {
         clear_tool_handlers();
         assert!(!has_tool_handler("custom_kind"));
@@ -642,6 +650,7 @@ mod tests {
     }
 
     #[test]
+    #[serial]
     fn test_clear_tools() {
         register_tool("temp", |_| async { Ok("ok".into()) });
         assert!(has_tool("temp"));
@@ -650,6 +659,7 @@ mod tests {
     }
 
     #[test]
+    #[serial]
     fn test_clear_tool_handlers() {
         register_tool_handler("temp_kind", FunctionToolHandler);
         assert!(has_tool_handler("temp_kind"));
@@ -658,6 +668,7 @@ mod tests {
     }
 
     #[test]
+    #[serial]
     fn test_register_builtin_handlers() {
         clear_tool_handlers();
         register_builtin_handlers();
@@ -671,6 +682,7 @@ mod tests {
     // --- resolve_bindings tests ---
 
     #[test]
+    #[serial]
     fn test_resolve_bindings_injects_values() {
         let agent = agent_with_tools(serde_json::json!([{
             "name": "get_weather",
@@ -689,6 +701,7 @@ mod tests {
     }
 
     #[test]
+    #[serial]
     fn test_resolve_bindings_no_bindings_passthrough() {
         let agent = agent_with_tools(serde_json::json!([{
             "name": "get_weather",
@@ -703,6 +716,7 @@ mod tests {
     }
 
     #[test]
+    #[serial]
     fn test_resolve_bindings_missing_input_skipped() {
         let agent = agent_with_tools(serde_json::json!([{
             "name": "get_weather",
@@ -720,6 +734,7 @@ mod tests {
     }
 
     #[test]
+    #[serial]
     fn test_resolve_bindings_multiple() {
         let agent = agent_with_tools(serde_json::json!([{
             "name": "get_weather",
@@ -742,6 +757,7 @@ mod tests {
     }
 
     #[test]
+    #[serial]
     fn test_resolve_bindings_no_tool_def() {
         let agent = default_agent();
         let args = serde_json::json!({ "city": "Paris" });
@@ -754,6 +770,7 @@ mod tests {
     // --- Kind handler tests ---
 
     #[tokio::test]
+    #[serial]
     async fn test_mcp_handler_not_implemented() {
         let handler = McpToolHandler;
         let result = handler
@@ -769,6 +786,7 @@ mod tests {
     }
 
     #[tokio::test]
+    #[serial]
     async fn test_openapi_handler_not_implemented() {
         let handler = OpenApiToolHandler;
         let result = handler
@@ -784,6 +802,7 @@ mod tests {
     }
 
     #[tokio::test]
+    #[serial]
     async fn test_custom_handler_not_implemented() {
         let handler = CustomToolHandler;
         let result = handler
@@ -799,6 +818,7 @@ mod tests {
     }
 
     #[tokio::test]
+    #[serial]
     async fn test_dispatch_bindings_integrated() {
         clear_tools();
         clear_tool_handlers();
@@ -828,6 +848,7 @@ mod tests {
     // --- PromptyToolHandler tests ---
 
     #[tokio::test]
+    #[serial]
     async fn test_prompty_handler_missing_source_path() {
         let handler = PromptyToolHandler;
         // Agent without __source_path metadata
@@ -839,6 +860,7 @@ mod tests {
     }
 
     #[tokio::test]
+    #[serial]
     async fn test_prompty_handler_missing_path_field() {
         let handler = PromptyToolHandler;
         let mut agent = default_agent();
@@ -851,6 +873,7 @@ mod tests {
     }
 
     #[tokio::test]
+    #[serial]
     async fn test_prompty_handler_circular_reference_detection() {
         let handler = PromptyToolHandler;
         let mut agent = default_agent();
@@ -876,6 +899,7 @@ mod tests {
     }
 
     #[tokio::test]
+    #[serial]
     async fn test_prompty_handler_nonexistent_child() {
         let handler = PromptyToolHandler;
         let mut agent = default_agent();
@@ -900,6 +924,7 @@ mod tests {
     // --- Kind handler dispatch via dispatch_tool (layer 3) ---
 
     #[tokio::test]
+    #[serial]
     async fn test_dispatch_layer3_kind_handler() {
         clear_tools();
         clear_tool_handlers();
@@ -920,6 +945,7 @@ mod tests {
     }
 
     #[tokio::test]
+    #[serial]
     async fn test_dispatch_layer3_wildcard_handler() {
         clear_tools();
         clear_tool_handlers();

--- a/runtime/rust/prompty/src/tracing/prompty_tracer.rs
+++ b/runtime/rust/prompty/src/tracing/prompty_tracer.rs
@@ -244,6 +244,7 @@ impl TracerFactory for PromptyTracer {
 mod tests {
     use super::*;
     use crate::tracing::tracer::Tracer;
+    use serial_test::serial;
     use serde_json::json;
     use std::fs;
 
@@ -274,9 +275,10 @@ mod tests {
     }
 
     #[test]
+    #[serial]
     fn test_tracy_file_written() {
         Tracer::clear();
-        let dir = std::env::temp_dir().join("prompty_test_tracy");
+        let dir = std::env::temp_dir().join(format!("prompty_test_tracy_{:?}", std::thread::current().id()));
         let _ = fs::remove_dir_all(&dir);
         fs::create_dir_all(&dir).unwrap();
 

--- a/runtime/rust/prompty/tests/loader_test.rs
+++ b/runtime/rust/prompty/tests/loader_test.rs
@@ -3,6 +3,7 @@
 //! These tests exercise the full load pipeline: frontmatter splitting, reference
 //! resolution, model shorthand expansion, and typed construction.
 
+use serial_test::serial;
 use std::path::PathBuf;
 
 /// Path to the spec fixtures directory.
@@ -64,6 +65,7 @@ fn load_from_frontmatter(
 // ===== Spec vector tests =====
 
 #[test]
+#[serial]
 fn test_basic_load() {
     let agent = load_fixture(
         "basic.prompty",
@@ -112,6 +114,7 @@ fn test_basic_load() {
 }
 
 #[test]
+#[serial]
 fn test_minimal_load() {
     let agent = load_fixture("minimal.prompty", &[]).unwrap();
 
@@ -124,6 +127,7 @@ fn test_minimal_load() {
 }
 
 #[test]
+#[serial]
 fn test_model_shorthand() {
     let fm = serde_json::json!({
         "name": "test",
@@ -134,6 +138,7 @@ fn test_model_shorthand() {
 }
 
 #[test]
+#[serial]
 fn test_env_resolution() {
     let fm = serde_json::json!({
         "name": "env-test",
@@ -151,6 +156,7 @@ fn test_env_resolution() {
 }
 
 #[test]
+#[serial]
 fn test_env_default() {
     let fm = serde_json::json!({
         "name": "env-default-test",
@@ -168,6 +174,7 @@ fn test_env_default() {
 }
 
 #[test]
+#[serial]
 fn test_env_missing_error() {
     let fm = serde_json::json!({
         "name": "env-error-test",
@@ -186,6 +193,7 @@ fn test_env_missing_error() {
 }
 
 #[test]
+#[serial]
 fn test_kind_always_prompt() {
     let agent = load_fixture("minimal.prompty", &[]).unwrap();
     // The kind is injected but not stored as a field on Prompty — it's
@@ -195,12 +203,14 @@ fn test_kind_always_prompt() {
 }
 
 #[test]
+#[serial]
 fn test_missing_file_error() {
     let result = prompty::load(fixtures_dir().join("nonexistent.prompty"));
     assert!(result.is_err());
 }
 
 #[test]
+#[serial]
 fn test_invalid_frontmatter_error() {
     let raw = "---\nname: [invalid\n---\nHello";
     let result = prompty::load_from_string(raw, std::env::current_dir().unwrap());
@@ -214,6 +224,7 @@ fn test_invalid_frontmatter_error() {
 }
 
 #[test]
+#[serial]
 fn test_instructions_from_body() {
     let agent = load_fixture(
         "basic.prompty",
@@ -229,6 +240,7 @@ fn test_instructions_from_body() {
 }
 
 #[test]
+#[serial]
 fn test_tools_function_load() {
     let agent = load_fixture("tools_function.prompty", &[]).unwrap();
 
@@ -242,6 +254,7 @@ fn test_tools_function_load() {
 }
 
 #[test]
+#[serial]
 fn test_embedding_load() {
     let agent = load_fixture(
         "embedding.prompty",
@@ -258,6 +271,7 @@ fn test_embedding_load() {
 }
 
 #[test]
+#[serial]
 fn test_empty_frontmatter_body_only() {
     let fm = serde_json::json!({
         "name": "empty-fm"
@@ -269,6 +283,7 @@ fn test_empty_frontmatter_body_only() {
 }
 
 #[test]
+#[serial]
 fn test_connection_types_load() {
     let fm = serde_json::json!({
         "name": "connection-test",
@@ -287,6 +302,7 @@ fn test_connection_types_load() {
 }
 
 #[test]
+#[serial]
 fn test_input_scalar_shorthand() {
     let fm = serde_json::json!({
         "name": "scalar-test",
@@ -306,6 +322,7 @@ fn test_input_scalar_shorthand() {
 }
 
 #[test]
+#[serial]
 fn test_tools_mcp_load() {
     let fm = serde_json::json!({
         "name": "mcp-test",
@@ -327,6 +344,7 @@ fn test_tools_mcp_load() {
 }
 
 #[test]
+#[serial]
 fn test_tools_openapi_load() {
     let fm = serde_json::json!({
         "name": "openapi-test",
@@ -348,6 +366,7 @@ fn test_tools_openapi_load() {
 }
 
 #[test]
+#[serial]
 fn test_tools_custom_load() {
     let fm = serde_json::json!({
         "name": "custom-tool-test",
@@ -368,6 +387,7 @@ fn test_tools_custom_load() {
 }
 
 #[test]
+#[serial]
 fn test_metadata_preserved() {
     let agent = load_fixture(
         "basic.prompty",
@@ -387,6 +407,7 @@ fn test_metadata_preserved() {
 }
 
 #[test]
+#[serial]
 fn test_threaded_load() {
     let agent = load_fixture("threaded.prompty", &[]).unwrap();
     assert_eq!(agent.name, "threaded-chat");


### PR DESCRIPTION
## Summary

Prepares all 4 Rust crates (`prompty`, `prompty-openai`, `prompty-anthropic`, `prompty-foundry`) for publishing to crates.io, aligned with the `2.0.0-alpha.8` version used by the Python, TypeScript, and C# runtimes.

## Changes

### Crate metadata & packaging
- Added `repository`, `documentation`, `readme`, `keywords`, `categories` to all 4 `Cargo.toml` files
- Versioned all path dependencies (`prompty = { version = "2.0.0-alpha.8", path = "../prompty" }`) for crates.io compatibility
- Added `tokio/rt` feature to core crate (needed for `spawn_blocking` in loader)
- Created `README.md` with usage docs for each crate
- Copied MIT `LICENSE` to each crate directory

### CI/CD workflows
- **`prompty-rust-check.yml`** — PR check workflow: build, test, `cargo fmt --check`, clippy on ubuntu + windows
- **`prompty-rust.yml`** — Tag-triggered publish workflow on `rust/*` tags (e.g., `rust/2.0.0-alpha.8`)
  - Extracts version from tag, rewrites all Cargo.toml versions
  - Publishes in dependency order: `prompty` → `prompty-openai` → `prompty-anthropic` → `prompty-foundry`
  - Uses `CARGO_REGISTRY_TOKEN` secret

### Test stability
- Added `serial_test` dev-dependency to all 4 crates
- Marked all tests touching global state (registries, connections, env vars) with `#[serial]` to eliminate race conditions from parallel test execution

### Bug fix
- Fixed wire format for bare `array`/`object` types to emit minimal JSON Schema per spec vectors

## Publishing

After merge, push a tag to publish:
```bash
git tag rust/2.0.0-alpha.8
git push origin rust/2.0.0-alpha.8
```

## Dry-run verified
`cargo publish --dry-run` passes for the core crate.