### PR TITLE
fix: resolve all clippy lints in Rust workspace

### DIFF
--- a/runtime/rust/prompty-anthropic/src/processor.rs
+++ b/runtime/rust/prompty-anthropic/src/processor.rs
@@ -44,7 +44,9 @@ pub fn process_response(agent: &Prompty, response: &Value) -> Result<Value, Invo
         .and_then(|c| c.as_array())
         .ok_or_else(|| {
             InvokerError::Process(
-                format!("Invalid Anthropic response: missing 'content' array").into(),
+                "Invalid Anthropic response: missing 'content' array"
+                    .to_string()
+                    .into(),
             )
         })?;
 

--- a/runtime/rust/prompty-openai/src/wire.rs
+++ b/runtime/rust/prompty-openai/src/wire.rs
@@ -257,7 +257,7 @@ pub fn tools_to_wire(agent: &Prompty) -> Vec<Value> {
     tools
         .iter()
         .filter(|tool| matches!(tool.kind, ToolKind::Function { .. }))
-        .map(|tool| function_tool_to_wire(tool))
+        .map(function_tool_to_wire)
         .collect()
 }
 
@@ -551,7 +551,7 @@ fn responses_tools_to_wire(agent: &Prompty) -> Vec<Value> {
     tools
         .iter()
         .filter(|tool| matches!(tool.kind, ToolKind::Function { .. }))
-        .map(|tool| responses_function_tool_to_wire(tool))
+        .map(responses_function_tool_to_wire)
         .collect()
 }
 

--- a/runtime/rust/prompty/src/context.rs
+++ b/runtime/rust/prompty/src/context.rs
@@ -143,7 +143,7 @@ pub fn trim_to_context_window(messages: &[Message], budget_chars: usize) -> (usi
     let summary_text = summarize_dropped(dropped);
     let summary_msg = Message::text(
         Role::User,
-        &format!("[Context summary: {summary_text}\n... ({drop_count} messages omitted)]"),
+        format!("[Context summary: {summary_text}\n... ({drop_count} messages omitted)]"),
     );
 
     let mut result = Vec::with_capacity(system_msgs.len() + 1 + kept.len());

--- a/runtime/rust/prompty/src/guardrails.rs
+++ b/runtime/rust/prompty/src/guardrails.rs
@@ -114,6 +114,7 @@ pub type ToolGuardrail = Box<
 /// Guardrail configuration for the agent loop.
 ///
 /// All fields are optional — missing guardrails default to "allowed".
+#[derive(Default)]
 pub struct Guardrails {
     /// Checked before each LLM call.
     pub input: Option<InputGuardrail>,
@@ -121,16 +122,6 @@ pub struct Guardrails {
     pub output: Option<OutputGuardrail>,
     /// Checked before each tool execution.
     pub tool: Option<ToolGuardrail>,
-}
-
-impl Default for Guardrails {
-    fn default() -> Self {
-        Self {
-            input: None,
-            output: None,
-            tool: None,
-        }
-    }
 }
 
 impl Guardrails {

--- a/runtime/rust/prompty/src/model/connection.rs
+++ b/runtime/rust/prompty/src/model/connection.rs
@@ -194,7 +194,7 @@ impl Connection {
                 .get("usageDescription")
                 .and_then(|v| v.as_str())
                 .map(|s| s.to_string()),
-            kind: kind,
+            kind,
         }
     }
 

--- a/runtime/rust/prompty/src/model/context.rs
+++ b/runtime/rust/prompty/src/model/context.rs
@@ -17,6 +17,7 @@ pub type PostSaveFn = Box<dyn Fn(serde_json::Value) -> serde_json::Value + Send 
 ///
 /// Provides hooks for pre-processing input data before parsing and
 /// post-processing output data after instantiation.
+#[derive(Default)]
 pub struct LoadContext {
     /// Optional callback to transform input data before parsing.
     pub pre_process: Option<PreProcessFn>,
@@ -30,15 +31,6 @@ impl std::fmt::Debug for LoadContext {
             .field("pre_process", &self.pre_process.as_ref().map(|_| "..."))
             .field("post_process", &self.post_process.as_ref().map(|_| "..."))
             .finish()
-    }
-}
-
-impl Default for LoadContext {
-    fn default() -> Self {
-        Self {
-            pre_process: None,
-            post_process: None,
-        }
     }
 }
 

--- a/runtime/rust/prompty/src/model/mod.rs
+++ b/runtime/rust/prompty/src/model/mod.rs
@@ -12,6 +12,7 @@ pub use connection::*;
 pub mod model_options;
 pub use model_options::*;
 
+#[allow(clippy::module_inception)]
 pub mod model;
 pub use model::*;
 

--- a/runtime/rust/prompty/src/model/property.rs
+++ b/runtime/rust/prompty/src/model/property.rs
@@ -123,7 +123,7 @@ impl Property {
                 .get("enumValues")
                 .and_then(|v| v.as_array())
                 .map(|arr| arr.to_vec()),
-            kind: kind,
+            kind,
         }
     }
 

--- a/runtime/rust/prompty/src/model/tool.rs
+++ b/runtime/rust/prompty/src/model/tool.rs
@@ -185,7 +185,7 @@ impl Tool {
                 .get("bindings")
                 .cloned()
                 .unwrap_or(serde_json::Value::Null),
-            kind: kind,
+            kind,
         }
     }
 

--- a/runtime/rust/prompty/src/pipeline.rs
+++ b/runtime/rust/prompty/src/pipeline.rs
@@ -636,6 +636,7 @@ pub struct TurnOptions {
     /// If true, dispatch tool calls in parallel (via tokio::join!).
     pub parallel_tool_calls: bool,
     /// Optional validator for structured output (called via cast after processing).
+    #[allow(clippy::type_complexity)]
     pub validator: Option<Box<dyn Fn(&serde_json::Value) -> Result<(), String> + Send + Sync>>,
 }
 
@@ -770,8 +771,8 @@ pub async fn turn(
                         span.end();
                         return Ok(raw_response);
                     }
-                    let p = process(agent, raw_response).await?;
-                    p
+
+                    process(agent, raw_response).await?
                 }
             }
         } else {
@@ -783,8 +784,7 @@ pub async fn turn(
                 return Ok(raw_response);
             }
 
-            let p = process(agent, raw_response).await?;
-            p
+            process(agent, raw_response).await?
         };
 
         // Output guardrail

--- a/runtime/rust/prompty/src/structured.rs
+++ b/runtime/rust/prompty/src/structured.rs
@@ -91,6 +91,7 @@ pub fn unwrap_structured(value: &Value) -> Value {
 /// Optionally runs a `validator` function on the deserialized result.
 ///
 /// Matches TypeScript's `cast<T>(result, validator?)`.
+#[allow(clippy::type_complexity)]
 pub fn cast<T>(
     value: &Value,
     validator: Option<&dyn Fn(&T) -> Result<(), String>>,


### PR DESCRIPTION
Resolves all `cargo clippy -- -D warnings` failures that blocked the `rust/2.0.0-alpha.8` publish workflow.

**Auto-fixed**: `redundant_field_names`, `needless_borrows_for_generic_args`, `derivable_impls`, `let_and_return`  
**Allowed**: `type_complexity` on 2 intentionally complex validator types, `module_inception` on `model::model` (matches crate convention)  
**Re-formatted** after clippy auto-fix to keep `cargo fmt` clean.