### PR TITLE
fix(rust): align runtime with spec + add Rust docs

### DIFF
--- a/runtime/rust/prompty-anthropic/src/processor.rs
+++ b/runtime/rust/prompty-anthropic/src/processor.rs
@@ -99,16 +99,9 @@ pub fn process_response(agent: &Prompty, response: &Value) -> Result<Value, Invo
     let has_outputs = agent.as_outputs().map(|o| !o.is_empty()).unwrap_or(false);
 
     if has_outputs {
-        // Parse text as JSON for structured output
-        match serde_json::from_str::<Value>(&text) {
-            Ok(parsed) => {
-                return Ok(parsed);
-            }
-            Err(e) => {
-                return Err(InvokerError::Process(
-                    format!("Failed to parse structured output: {e}").into(),
-                ));
-            }
+        // Per spec §8.1: try JSON parse, fall back to raw string on failure
+        if let Ok(parsed) = serde_json::from_str::<Value>(&text) {
+            return Ok(parsed);
         }
     }
 
@@ -232,6 +225,18 @@ impl futures::Stream for AnthropicStreamProcessor {
                                                 if let Some(acc) = this.tool_call_acc.get_mut(&idx)
                                                 {
                                                     acc.2.push_str(partial);
+                                                }
+                                            }
+                                        }
+                                        "thinking_delta" => {
+                                            // Per spec §13.1: emit Thinking events for reasoning/chain-of-thought
+                                            if let Some(thinking) =
+                                                delta.get("thinking").and_then(Value::as_str)
+                                            {
+                                                if !thinking.is_empty() {
+                                                    return Poll::Ready(Some(
+                                                        StreamChunk::Thinking(thinking.to_string()),
+                                                    ));
                                                 }
                                             }
                                         }

--- a/runtime/rust/prompty-openai/src/processor.rs
+++ b/runtime/rust/prompty-openai/src/processor.rs
@@ -336,11 +336,14 @@ impl futures::Stream for OpenAIStreamProcessor {
                                 }
                             }
 
-                            // Refusal
+                            // Refusal — per spec §10.3: MUST raise error, stream MUST NOT continue
                             if let Some(refusal) = delta.get("refusal").and_then(Value::as_str) {
-                                return std::task::Poll::Ready(Some(StreamChunk::Text(format!(
-                                    "Model refused: {refusal}"
-                                ))));
+                                if !refusal.is_empty() {
+                                    this.phase = StreamPhase::Done;
+                                    return std::task::Poll::Ready(Some(StreamChunk::Error(
+                                        format!("Model refused: {refusal}"),
+                                    )));
+                                }
                             }
                         }
 
@@ -713,6 +716,7 @@ mod tests {
             match chunk {
                 StreamChunk::Text(t) => texts.push(t),
                 StreamChunk::Tool(_) => panic!("unexpected tool call"),
+                _ => {}
             }
         }
         assert_eq!(texts.join(""), "Hello world");
@@ -736,6 +740,7 @@ mod tests {
             match chunk {
                 StreamChunk::Text(_) => {}
                 StreamChunk::Tool(tc) => tools.push(tc),
+                _ => {}
             }
         }
         assert_eq!(tools.len(), 1);
@@ -750,14 +755,14 @@ mod tests {
         let chunks = vec![json!({"choices": [{"delta": {"refusal": "I cannot help with that"}}]})];
         let inner = futures::stream::iter(chunks);
         let mut stream = process_stream(inner);
-        let mut texts = Vec::new();
+        let mut errors = Vec::new();
         while let Some(chunk) = stream.next().await {
-            if let StreamChunk::Text(t) = chunk {
-                texts.push(t);
+            if let StreamChunk::Error(e) = chunk {
+                errors.push(e);
             }
         }
-        assert_eq!(texts.len(), 1);
-        assert!(texts[0].contains("refused"));
+        assert_eq!(errors.len(), 1);
+        assert!(errors[0].contains("refused"));
     }
 
     #[tokio::test]
@@ -793,6 +798,7 @@ mod tests {
             match chunk {
                 StreamChunk::Text(t) => texts.push(t),
                 StreamChunk::Tool(tc) => tools.push(tc),
+                _ => {}
             }
         }
         assert_eq!(texts.join(""), "Let me check...");

--- a/runtime/rust/prompty-openai/src/wire.rs
+++ b/runtime/rust/prompty-openai/src/wire.rs
@@ -58,7 +58,7 @@ fn part_to_wire(part: &ContentPart) -> Value {
                 .media_type
                 .as_deref()
                 .map(mime_to_audio_format)
-                .unwrap_or("wav");
+                .unwrap_or_else(|| "wav".to_string());
             json!({
                 "type": "input_audio",
                 "input_audio": {
@@ -74,16 +74,17 @@ fn part_to_wire(part: &ContentPart) -> Value {
     }
 }
 
-fn mime_to_audio_format(mime: &str) -> &str {
+fn mime_to_audio_format(mime: &str) -> String {
     match mime {
-        "audio/wav" | "audio/x-wav" => "wav",
-        "audio/mpeg" | "audio/mp3" => "mp3",
-        "audio/mp4" => "mp4",
-        "audio/ogg" => "ogg",
-        "audio/flac" => "flac",
-        "audio/webm" => "webm",
-        "audio/pcm" => "pcm",
-        _ => "wav",
+        "audio/wav" | "audio/x-wav" => "wav".to_string(),
+        "audio/mpeg" | "audio/mp3" => "mp3".to_string(),
+        "audio/mp4" => "mp4".to_string(),
+        "audio/ogg" => "ogg".to_string(),
+        "audio/flac" => "flac".to_string(),
+        "audio/webm" => "webm".to_string(),
+        "audio/pcm" => "pcm".to_string(),
+        // Per spec §7.1.2: strip "audio/" prefix for unmapped types
+        other => other.strip_prefix("audio/").unwrap_or("wav").to_string(),
     }
 }
 
@@ -766,6 +767,11 @@ mod tests {
         assert_eq!(mime_to_audio_format("audio/flac"), "flac");
         assert_eq!(mime_to_audio_format("audio/webm"), "webm");
         assert_eq!(mime_to_audio_format("audio/pcm"), "pcm");
+        // Per spec §7.1.2: unmapped audio/* types strip the prefix
+        assert_eq!(mime_to_audio_format("audio/aac"), "aac");
+        assert_eq!(mime_to_audio_format("audio/opus"), "opus");
+        // Non-audio MIME falls back to "wav"
+        assert_eq!(mime_to_audio_format("text/plain"), "wav");
     }
 
     #[test]

--- a/runtime/rust/prompty/src/pipeline.rs
+++ b/runtime/rust/prompty/src/pipeline.rs
@@ -668,7 +668,11 @@ impl TurnOptions {
 
     fn emit(&self, event: AgentEvent) {
         if let Some(ref cb) = self.on_event {
-            cb(event);
+            // Per spec §13.1: event callbacks MUST NOT block the loop.
+            // If a callback panics, log and continue.
+            if let Err(e) = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| cb(event))) {
+                eprintln!("[prompty] Event callback panicked: {e:?}");
+            }
         }
     }
 
@@ -755,9 +759,20 @@ pub async fn turn(
                     let mut text_parts = Vec::new();
                     futures::pin_mut!(chunk_stream);
                     while let Some(chunk) = chunk_stream.next().await {
-                        if let StreamChunk::Text(t) = chunk {
-                            opts.emit(AgentEvent::Token(t.clone()));
-                            text_parts.push(t);
+                        match chunk {
+                            StreamChunk::Text(t) => {
+                                opts.emit(AgentEvent::Token(t.clone()));
+                                text_parts.push(t);
+                            }
+                            StreamChunk::Thinking(t) => {
+                                opts.emit(AgentEvent::Thinking(t));
+                            }
+                            StreamChunk::Error(e) => {
+                                span.emit("error", &json!(e));
+                                span.end();
+                                return Err(InvokerError::Execute(e.into()));
+                            }
+                            _ => {}
                         }
                     }
                     json!(text_parts.join(""))
@@ -842,11 +857,18 @@ pub async fn turn(
         iter_span.emit("iteration", &json!(iteration));
 
         // Drain steering messages
-        if let Some(ref mut steering) = opts.steering {
+        if let Some(ref steering) = opts.steering {
             let steering_msgs = steering.drain();
             if !steering_msgs.is_empty() {
-                iter_span.emit("steering_messages", &json!(steering_msgs.len()));
+                let count = steering_msgs.len();
+                iter_span.emit("steering_messages", &json!(count));
                 messages.extend(steering_msgs);
+                opts.emit(AgentEvent::Status(format!(
+                    "Injected {count} steering message(s)"
+                )));
+                opts.emit(AgentEvent::MessagesUpdated {
+                    messages: messages.clone(),
+                });
             }
         }
 
@@ -855,8 +877,13 @@ pub async fn turn(
             let (dropped, trimmed) = crate::context::trim_to_context_window(&messages, budget);
             if dropped > 0 {
                 iter_span.emit("context_trimmed", &json!(dropped));
+                messages = trimmed;
+                opts.emit(AgentEvent::MessagesUpdated {
+                    messages: messages.clone(),
+                });
+            } else {
+                messages = trimmed;
             }
-            messages = trimmed;
         }
 
         // Input guardrail
@@ -887,6 +914,7 @@ pub async fn turn(
                         use futures::StreamExt;
                         let mut tool_calls_vec = Vec::new();
                         let mut text_parts = Vec::new();
+                        let mut stream_error = None;
                         futures::pin_mut!(chunk_stream);
                         while let Some(chunk) = chunk_stream.next().await {
                             match chunk {
@@ -894,10 +922,23 @@ pub async fn turn(
                                     opts.emit(AgentEvent::Token(t.clone()));
                                     text_parts.push(t);
                                 }
+                                StreamChunk::Thinking(t) => {
+                                    opts.emit(AgentEvent::Thinking(t));
+                                }
                                 StreamChunk::Tool(tc) => {
                                     tool_calls_vec.push(tc);
                                 }
+                                StreamChunk::Error(e) => {
+                                    stream_error = Some(e);
+                                    break;
+                                }
                             }
+                        }
+                        if let Some(err) = stream_error {
+                            iter_span.end();
+                            span.emit("error", &json!(err));
+                            span.end();
+                            return Err(InvokerError::Execute(err.into()));
                         }
                         (tool_calls_vec, text_parts.join(""))
                     };

--- a/runtime/rust/prompty/src/steering.rs
+++ b/runtime/rust/prompty/src/steering.rs
@@ -1,9 +1,10 @@
 //! Steering — inject messages between agent loop iterations.
 //!
-//! Matches TypeScript `core/steering.ts`. A simple FIFO string queue
+//! Matches TypeScript `core/steering.ts`. A thread-safe FIFO string queue
 //! that converts queued strings to `user` messages when drained.
 
 use std::collections::VecDeque;
+use std::sync::{Arc, Mutex};
 
 use crate::types::{Message, Role};
 
@@ -11,13 +12,16 @@ use crate::types::{Message, Role};
 // Steering
 // ---------------------------------------------------------------------------
 
-/// A FIFO queue of steering messages to inject into the agent loop.
+/// A thread-safe FIFO queue of steering messages to inject into the agent loop.
+///
+/// Per spec §13.5, `send()` MUST be safe to call from any thread while the
+/// agent loop is running, and `drain()` MUST atomically remove all messages.
 ///
 /// Usage:
 /// ```
 /// use prompty::steering::Steering;
 ///
-/// let mut s = Steering::new();
+/// let s = Steering::new();
 /// s.send("Please use the search tool first.");
 /// s.send("Remember to cite sources.");
 ///
@@ -25,28 +29,34 @@ use crate::types::{Message, Role};
 /// let messages = s.drain();
 /// // → [Message { role: User, content: "Please use..." }, Message { role: User, content: "Remember..." }]
 /// ```
+#[derive(Clone)]
 pub struct Steering {
-    queue: VecDeque<String>,
+    queue: Arc<Mutex<VecDeque<String>>>,
 }
 
 impl Steering {
     /// Create a new empty Steering queue.
     pub fn new() -> Self {
         Self {
-            queue: VecDeque::new(),
+            queue: Arc::new(Mutex::new(VecDeque::new())),
         }
     }
 
-    /// Enqueue a steering message (as a plain string).
-    pub fn send(&mut self, message: impl Into<String>) {
-        self.queue.push_back(message.into());
+    /// Enqueue a steering message (as a plain string). Thread-safe.
+    pub fn send(&self, message: impl Into<String>) {
+        self.queue
+            .lock()
+            .expect("steering lock poisoned")
+            .push_back(message.into());
     }
 
-    /// Drain all queued messages, converting them to `user` Messages.
+    /// Atomically drain all queued messages, converting them to `user` Messages.
     ///
     /// The queue is emptied after calling this.
-    pub fn drain(&mut self) -> Vec<Message> {
+    pub fn drain(&self) -> Vec<Message> {
         self.queue
+            .lock()
+            .expect("steering lock poisoned")
             .drain(..)
             .map(|text| Message::text(Role::User, &text))
             .collect()
@@ -54,17 +64,24 @@ impl Steering {
 
     /// Check if there are pending steering messages.
     pub fn has_pending(&self) -> bool {
-        !self.queue.is_empty()
+        !self
+            .queue
+            .lock()
+            .expect("steering lock poisoned")
+            .is_empty()
     }
 
     /// Get the number of pending messages.
     pub fn len(&self) -> usize {
-        self.queue.len()
+        self.queue.lock().expect("steering lock poisoned").len()
     }
 
     /// Check if the queue is empty.
     pub fn is_empty(&self) -> bool {
-        self.queue.is_empty()
+        self.queue
+            .lock()
+            .expect("steering lock poisoned")
+            .is_empty()
     }
 }
 
@@ -92,7 +109,7 @@ mod tests {
 
     #[test]
     fn test_send_and_drain() {
-        let mut s = Steering::new();
+        let s = Steering::new();
         s.send("First message");
         s.send("Second message");
 
@@ -112,14 +129,14 @@ mod tests {
 
     #[test]
     fn test_drain_empty() {
-        let mut s = Steering::new();
+        let s = Steering::new();
         let msgs = s.drain();
         assert!(msgs.is_empty());
     }
 
     #[test]
     fn test_fifo_order() {
-        let mut s = Steering::new();
+        let s = Steering::new();
         s.send("A");
         s.send("B");
         s.send("C");
@@ -134,5 +151,18 @@ mod tests {
     fn test_default() {
         let s = Steering::default();
         assert!(s.is_empty());
+    }
+
+    #[test]
+    fn test_thread_safe_send() {
+        let s = Steering::new();
+        let s2 = s.clone();
+        let handle = std::thread::spawn(move || {
+            s2.send("from another thread");
+        });
+        handle.join().unwrap();
+        assert_eq!(s.len(), 1);
+        let msgs = s.drain();
+        assert_eq!(msgs[0].text_content(), "from another thread");
     }
 }

--- a/runtime/rust/prompty/src/types.rs
+++ b/runtime/rust/prompty/src/types.rs
@@ -427,8 +427,12 @@ impl Drop for PromptyStream {
 pub enum StreamChunk {
     /// A text content token.
     Text(String),
+    /// A thinking/reasoning token from the LLM.
+    Thinking(String),
     /// A completed tool call (yielded at end of stream).
     Tool(ToolCall),
+    /// A stream error (e.g., model refusal). Consumers MUST stop iteration.
+    Error(String),
 }
 
 // ---------------------------------------------------------------------------
@@ -457,8 +461,15 @@ pub async fn consume_stream_chunks(
                 }
                 text_parts.push(t);
             }
+            StreamChunk::Thinking(_) => {
+                // Thinking tokens are informational; not collected into output
+            }
             StreamChunk::Tool(tc) => {
                 tool_calls.push(tc);
+            }
+            StreamChunk::Error(_) => {
+                // Error chunks signal stream termination; stop consuming
+                break;
             }
         }
     }

--- a/web/docs-examples/rust/Cargo.toml
+++ b/web/docs-examples/rust/Cargo.toml
@@ -1,0 +1,27 @@
+[package]
+name = "prompty-docs-examples"
+version = "0.1.0"
+edition = "2024"
+publish = false
+
+[dependencies]
+prompty = { version = "2.0.0-alpha.8" }
+prompty-openai = { version = "2.0.0-alpha.8" }
+serde_json = "1"
+tokio = { version = "1", features = ["full"] }
+
+[[example]]
+name = "chat_basic"
+path = "examples/chat_basic.rs"
+
+[[example]]
+name = "streaming"
+path = "examples/streaming.rs"
+
+[[example]]
+name = "agent_tool_calling"
+path = "examples/agent_tool_calling.rs"
+
+[[example]]
+name = "structured_output"
+path = "examples/structured_output.rs"

--- a/web/docs-examples/rust/examples/agent_tool_calling.rs
+++ b/web/docs-examples/rust/examples/agent_tool_calling.rs
@@ -1,0 +1,45 @@
+use prompty::TurnOptions;
+use serde_json::json;
+use std::sync::Arc;
+
+#[tokio::main]
+async fn main() -> Result<(), Box<dyn std::error::Error>> {
+    prompty::register_defaults();
+    prompty_openai::register();
+
+    // Register tool handlers
+    prompty::register_tool_handler("get_weather", |args| {
+        Box::pin(async move {
+            let city = args["city"].as_str().unwrap_or("unknown");
+            Ok(json!(format!("72°F and sunny in {city}")))
+        })
+    });
+
+    prompty::register_tool_handler("get_time", |args| {
+        Box::pin(async move {
+            let timezone = args["timezone"].as_str().unwrap_or("UTC");
+            Ok(json!(format!("2025-01-15T10:30:00 {timezone}")))
+        })
+    });
+
+    // Load agent and run with tool-calling loop
+    let agent = prompty::load("weather_agent.prompty")?;
+
+    let options = TurnOptions {
+        max_iterations: Some(10),
+        events: Some(Arc::new(|event| {
+            println!("Agent event: {event:?}");
+        })),
+        ..Default::default()
+    };
+
+    let result = prompty::turn(
+        &agent,
+        Some(&json!({ "question": "What's the weather in Seattle?" })),
+        Some(options),
+    )
+    .await?;
+
+    println!("Result: {result}");
+    Ok(())
+}

--- a/web/docs-examples/rust/examples/chat_basic.rs
+++ b/web/docs-examples/rust/examples/chat_basic.rs
@@ -1,0 +1,20 @@
+use serde_json::json;
+
+#[tokio::main]
+async fn main() -> Result<(), Box<dyn std::error::Error>> {
+    // Register built-in renderers/parsers and OpenAI provider
+    prompty::register_defaults();
+    prompty_openai::register();
+
+    // All-in-one: load → render → parse → execute → process
+    let result = prompty::invoke_from_path(
+        "greeting.prompty",
+        Some(&json!({ "userName": "Jane" })),
+    )
+    .await?;
+
+    println!("{result}");
+    // "Hello Jane! 👋 How's your day going so far?"
+
+    Ok(())
+}

--- a/web/docs-examples/rust/examples/streaming.rs
+++ b/web/docs-examples/rust/examples/streaming.rs
@@ -1,0 +1,28 @@
+use prompty::StreamChunk;
+use serde_json::json;
+
+#[tokio::main]
+async fn main() -> Result<(), Box<dyn std::error::Error>> {
+    prompty::register_defaults();
+    prompty_openai::register();
+
+    // Load agent and prepare messages
+    let agent = prompty::load("chat.prompty")?;
+    let messages = prompty::prepare(&agent, Some(&json!({ "question": "Tell me a joke" }))).await?;
+
+    // Run returns a PromptyStream when stream: true is set
+    let result = prompty::run(&agent, &messages).await?;
+
+    // Process streaming chunks
+    let stream = prompty::from_structured_value::<prompty::PromptyStream>(&result)?;
+    prompty::consume_stream_chunks(stream, |chunk| match chunk {
+        StreamChunk::Text(text) => print!("{text}"),
+        StreamChunk::Thinking(thought) => print!("[thinking] {thought}"),
+        StreamChunk::Tool(tc) => println!("[tool call] {}: {}", tc.name, tc.arguments),
+        StreamChunk::Error(err) => eprintln!("[error] {err}"),
+    })
+    .await;
+
+    println!();
+    Ok(())
+}

--- a/web/docs-examples/rust/examples/structured_output.rs
+++ b/web/docs-examples/rust/examples/structured_output.rs
@@ -1,0 +1,23 @@
+use serde_json::json;
+
+#[tokio::main]
+async fn main() -> Result<(), Box<dyn std::error::Error>> {
+    prompty::register_defaults();
+    prompty_openai::register();
+
+    // Load a .prompty file with outputSchema defined
+    let agent = prompty::load("structured.prompty")?;
+
+    let result = prompty::invoke_agent(
+        &agent,
+        Some(&json!({ "topic": "Rust programming language" })),
+    )
+    .await?;
+
+    // result is a parsed JSON object matching the outputSchema
+    println!("Title: {}", result["title"]);
+    println!("Summary: {}", result["summary"]);
+    println!("Tags: {}", result["tags"]);
+
+    Ok(())
+}

--- a/web/src/content/docs/api-reference/index.mdx
+++ b/web/src/content/docs/api-reference/index.mdx
@@ -38,6 +38,13 @@ Parse a `.prompty` file into a typed `Prompty` object.
     Console.WriteLine(agent.Model.Id); // "gpt-4o"
     ```
   </TabItem>
+  <TabItem label="Rust">
+    ```rust
+    let agent = prompty::load("chat.prompty")?;
+    println!("{}", agent.name());       // "chat"
+    println!("{}", agent.model().id()); // "gpt-4o"
+    ```
+  </TabItem>
 </Tabs>
 
 ### `render(agent, inputs) → str`
@@ -61,6 +68,12 @@ before parsing into messages.
   <TabItem label="C#">
     ```csharp
     var rendered = await Pipeline.RenderAsync(agent, new() { ["q"] = "Hi" });
+    // "system:\nYou are helpful.\n\nuser:\nHi"
+    ```
+  </TabItem>
+  <TabItem label="Rust">
+    ```rust
+    let rendered = prompty::render(&agent, Some(&json!({ "q": "Hi" }))).await?;
     // "system:\nYou are helpful.\n\nuser:\nHi"
     ```
   </TabItem>
@@ -89,6 +102,12 @@ Parse a rendered string into structured messages.
     // List<Message> with system and user messages
     ```
   </TabItem>
+  <TabItem label="Rust">
+    ```rust
+    let messages = prompty::parse(&agent, &rendered).await?;
+    // Vec<Message> with system and user messages
+    ```
+  </TabItem>
 </Tabs>
 
 ### `prepare(agent, inputs) → list[Message]`
@@ -111,6 +130,11 @@ wire-ready messages.
   <TabItem label="C#">
     ```csharp
     var messages = await Pipeline.PrepareAsync(agent, new() { ["q"] = "Hi" });
+    ```
+  </TabItem>
+  <TabItem label="Rust">
+    ```rust
+    let messages = prompty::prepare(&agent, Some(&json!({ "q": "Hi" }))).await?;
     ```
   </TabItem>
 </Tabs>
@@ -144,6 +168,15 @@ Composite: call the LLM executor then process the response.
     var response = await Pipeline.RunAsync(agent, messages, raw: true);
     ```
   </TabItem>
+  <TabItem label="Rust">
+    ```rust
+    let result = prompty::run(&agent, &messages).await?;
+    // "Hello! How can I help you?"
+
+    // Pass raw flag to get the raw SDK response
+    let response = prompty::run_raw(&agent, &messages).await?;
+    ```
+  </TabItem>
 </Tabs>
 
 ### `process(agent, response) → result`
@@ -167,6 +200,11 @@ Extract clean content from a raw LLM response.
     var result = await Pipeline.ProcessAsync(agent, response);
     ```
   </TabItem>
+  <TabItem label="Rust">
+    ```rust
+    let result = prompty::process(&agent, &response).await?;
+    ```
+  </TabItem>
 </Tabs>
 
 ### `invoke(path_or_agent, inputs) → result`
@@ -188,6 +226,11 @@ One-shot pipeline: load → prepare → execute → process.
   <TabItem label="C#">
     ```csharp
     var result = await Pipeline.InvokeAsync("chat.prompty", new() { ["q"] = "Hi" });
+    ```
+  </TabItem>
+  <TabItem label="Rust">
+    ```rust
+    let result = prompty::invoke_from_path("chat.prompty", Some(&json!({ "q": "Hi" }))).await?;
     ```
   </TabItem>
 </Tabs>
@@ -215,6 +258,12 @@ provided. Raises an error if any are missing.
     ```csharp
     Pipeline.ValidateInputs(agent, new() { ["name"] = "Jane" });
     // Throws ArgumentException if required fields are missing
+    ```
+  </TabItem>
+  <TabItem label="Rust">
+    ```rust
+    prompty::validate_inputs(&agent, &json!({ "name": "Jane" }))?;
+    // Returns Err(InvokerError) if required fields are missing
     ```
   </TabItem>
 </Tabs>
@@ -254,6 +303,16 @@ provided. Raises an error if any are missing.
     var agent = PromptyLoader.Load("chat.prompty");           // sync
     var messages = await Pipeline.PrepareAsync(agent, inputs); // async
     var result = await Pipeline.RunAsync(agent, messages);     // async
+    ```
+  </TabItem>
+  <TabItem label="Rust">
+    All pipeline functions are async by default — they return `Result<T>`.
+    Use `.await` on every call:
+
+    ```rust
+    let agent = prompty::load("chat.prompty")?;                          // sync
+    let messages = prompty::prepare(&agent, Some(&inputs)).await?;       // async
+    let result = prompty::run(&agent, &messages).await?;                 // async
     ```
   </TabItem>
 </Tabs>
@@ -308,6 +367,29 @@ Run a conversational turn with optional tool-calling loop.
         tools: tools,
         maxIterations: 10
     );
+    ```
+  </TabItem>
+  <TabItem label="Rust">
+    ```rust
+    use prompty::{self, TurnOptions};
+    use serde_json::json;
+
+    fn get_weather(location: &str) -> String {
+        format!("72°F and sunny in {location}")
+    }
+
+    prompty::register_tool_handler("get_weather", |args| {
+        Box::pin(async move {
+            let loc = args["location"].as_str().unwrap_or("unknown");
+            Ok(json!(get_weather(loc)))
+        })
+    });
+
+    let result = prompty::turn_from_path(
+        "agent.prompty",
+        Some(&json!({ "question": "Weather in Seattle?" })),
+        Some(TurnOptions { max_iterations: Some(10), ..Default::default() }),
+    ).await?;
     ```
   </TabItem>
 </Tabs>
@@ -388,6 +470,22 @@ can reference them via `connection.kind: reference`.
     ConnectionRegistry.Clear(); // useful in tests
     ```
   </TabItem>
+  <TabItem label="Rust">
+    ```rust
+    use prompty;
+    use serde_json::json;
+
+    prompty::register_connection("my-foundry", json!({
+        "kind": "key",
+        "endpoint": std::env::var("AZURE_ENDPOINT")?,
+        "apiKey": std::env::var("AZURE_API_KEY")?,
+    }));
+
+    // Lookup and clear
+    let conn = prompty::get_connection("my-foundry");
+    prompty::clear_connections(); // useful in tests
+    ```
+  </TabItem>
 </Tabs>
 
 Then in your `.prompty` file:
@@ -437,6 +535,21 @@ Set `stream: true` in model options:
         {
             Console.Write(chunk);
         }
+    }
+    ```
+  </TabItem>
+  <TabItem label="Rust">
+    ```rust
+    use prompty;
+    use serde_json::json;
+    use futures::StreamExt;
+
+    let agent = prompty::load("chat.prompty")?;
+    let messages = prompty::prepare(&agent, Some(&json!({}))).await?;
+
+    let mut stream = prompty::run_stream(&agent, &messages).await?;
+    while let Some(chunk) = stream.next().await {
+        print!("{chunk}");
     }
     ```
   </TabItem>
@@ -499,6 +612,21 @@ from `StructuredResult` when available — no dict→JSON→T round-trip.
     // Or: await Pipeline.InvokeAsync<Weather>("weather.prompty", inputs);
     ```
   </TabItem>
+  <TabItem label="Rust">
+    ```rust
+    use prompty;
+    use serde::Deserialize;
+
+    #[derive(Deserialize)]
+    struct Weather {
+        city: String,
+        temperature: i32,
+    }
+
+    let weather: Weather = prompty::cast(&result)?;
+    // Supports any type implementing serde::Deserialize
+    ```
+  </TabItem>
 </Tabs>
 
 ### Generic `invoke<T>` / `turn<T>`
@@ -526,6 +654,27 @@ Cast the final result in one step:
         new() { ["city"] = "Seattle" });
     var weather2 = await Pipeline.TurnAsync<Weather>("agent.prompty",
         new() { ["question"] = "..." }, tools: tools);
+    ```
+  </TabItem>
+  <TabItem label="Rust">
+    ```rust
+    use prompty;
+    use serde::Deserialize;
+    use serde_json::json;
+
+    #[derive(Deserialize)]
+    struct Weather { city: String, temperature: i32 }
+
+    let weather: Weather = prompty::invoke_from_path_typed(
+        "weather.prompty",
+        Some(&json!({ "city": "Seattle" })),
+    ).await?;
+
+    let weather2: Weather = prompty::turn_from_path_typed(
+        "agent.prompty",
+        Some(&json!({ "question": "..." })),
+        None,
+    ).await?;
     ```
   </TabItem>
 </Tabs>
@@ -585,6 +734,30 @@ Cast the final result in one step:
         var output = await DoWork();
         return output;
     });
+    ```
+  </TabItem>
+  <TabItem label="Rust">
+    ```rust
+    use prompty::{Tracer, PromptyTracer, console_tracer, trace_async};
+
+    // Console tracer
+    Tracer::register("console", console_tracer);
+
+    // JSON file tracer
+    let pt = PromptyTracer::new("./traces");
+    Tracer::register("file", pt.tracer());
+
+    // OpenTelemetry (feature-gated)
+    #[cfg(feature = "otel")]
+    {
+        prompty::init_otel_stdout();
+        Tracer::register("otel", prompty::otel_tracer());
+    }
+
+    // Trace your own async functions
+    let result = trace_async("my-operation", async {
+        // your code here
+    }).await;
     ```
   </TabItem>
 </Tabs>

--- a/web/src/content/docs/contributing/code-guidelines.mdx
+++ b/web/src/content/docs/contributing/code-guidelines.mdx
@@ -13,7 +13,7 @@ index: 2
 
 import { Tabs, TabItem, Aside } from '@astrojs/starlight/components';
 
-These guidelines cover coding conventions for the **Python**, **TypeScript**, and **C#** Prompty runtimes.
+These guidelines cover coding conventions for the **Python**, **TypeScript**, **C#**, and **Rust** Prompty runtimes.
 Following them keeps the codebase consistent and makes PRs easier to review.
 
 ## Repository Layout
@@ -381,6 +381,34 @@ public static class MyProviderExtensions
 
 4. Add a NuGet package spec in the project file.
 5. Add a test project `Prompty.MyProvider.Tests`.
+</TabItem>
+<TabItem label="Rust">
+1. Create `prompty-myprovider/` as a new crate in the workspace.
+2. Implement the `Executor` and `Processor` traits.
+3. Register via the global registry in a `register()` function:
+
+```rust
+// prompty-myprovider/src/lib.rs
+use prompty::{register_executor, register_processor, Executor, Processor};
+
+pub fn register() {
+    register_executor("myprovider", MyExecutor);
+    register_processor("myprovider", MyProcessor);
+}
+```
+
+4. Add the crate to the workspace `Cargo.toml`.
+5. Add tests using `#[tokio::test]` with `serial_test` for registry isolation.
+
+```rust
+// Rust ≥ 1.85, edition 2024
+// Async runtime: Tokio
+// Serialization: serde + serde_json + serde_yaml
+// HTTP: reqwest
+// Templates: minijinja (Nunjucks/Jinja2 compatible)
+// Error handling: thiserror
+// Testing: #[tokio::test] with serial_test for registry isolation
+```
 </TabItem>
 </Tabs>
 

--- a/web/src/content/docs/core-concepts/agent-extensions.mdx
+++ b/web/src/content/docs/core-concepts/agent-extensions.mdx
@@ -96,6 +96,31 @@ var result = await Pipeline.TurnAsync(
 );
 ```
 </TabItem>
+<TabItem label="Rust">
+```rust
+use prompty::{TurnOptions, AgentEvent};
+use std::sync::Arc;
+
+let agent = prompty::load("agent.prompty")?;
+
+let options = TurnOptions {
+    events: Some(Arc::new(|event: AgentEvent| {
+        match &event {
+            AgentEvent::Status(msg) => println!("Status: {msg}"),
+            AgentEvent::MessagesUpdated => println!("Messages updated"),
+            _ => println!("Event: {event:?}"),
+        }
+    })),
+    ..Default::default()
+};
+
+let result = prompty::turn(
+    &agent,
+    Some(&serde_json::json!({"question": "Hello"})),
+    Some(options),
+).await?;
+```
+</TabItem>
 </Tabs>
 
 ### Event Types
@@ -178,10 +203,38 @@ catch (OperationCanceledException)
 }
 ```
 </TabItem>
+<TabItem label="Rust">
+```rust
+use prompty::TurnOptions;
+use std::sync::{Arc, atomic::{AtomicBool, Ordering}};
+
+let cancel = Arc::new(AtomicBool::new(false));
+let cancel_clone = cancel.clone();
+
+// Cancel from another task after 5 seconds
+tokio::spawn(async move {
+    tokio::time::sleep(std::time::Duration::from_secs(5)).await;
+    cancel_clone.store(true, Ordering::SeqCst);
+});
+
+let options = TurnOptions {
+    cancellation_token: Some(cancel),
+    ..Default::default()
+};
+
+match prompty::turn(&agent, Some(&inputs), Some(options)).await {
+    Ok(result) => println!("{result}"),
+    Err(e) if e.to_string().contains("cancelled") => {
+        println!("Agent loop was cancelled");
+    }
+    Err(e) => return Err(e),
+}
+```
+</TabItem>
 </Tabs>
 
 <Aside type="note">
-  Python uses a custom `CancellationToken` (wrapping `threading.Event`),
+  Python uses a custom `CancellationToken`(wrapping `threading.Event`),
   TypeScript uses the native `AbortSignal`, and C# uses the native
   `System.Threading.CancellationToken`.
 </Aside>
@@ -219,6 +272,16 @@ var result = await Pipeline.TurnAsync(
     agent, inputs, tools,
     contextBudget: 50_000
 );
+```
+</TabItem>
+<TabItem label="Rust">
+```rust
+let options = TurnOptions {
+    context_window: Some(50_000),
+    ..Default::default()
+};
+
+let result = prompty::turn(&agent, Some(&inputs), Some(options)).await?;
 ```
 </TabItem>
 </Tabs>
@@ -336,6 +399,42 @@ catch (GuardrailError e)
 }
 ```
 </TabItem>
+<TabItem label="Rust">
+```rust
+use prompty::{TurnOptions, Guardrails, GuardrailResult};
+use std::sync::Arc;
+
+let guardrails = Guardrails {
+    input: vec![Arc::new(|msgs: &[prompty::Message]| {
+        Box::pin(async move {
+            for msg in msgs {
+                if msg.text().to_lowercase().contains("ignore previous instructions") {
+                    return Ok(GuardrailResult::Deny("Prompt injection detected".into()));
+                }
+            }
+            Ok(GuardrailResult::Allow)
+        })
+    })],
+    output: vec![],
+    tool: vec![Arc::new(|name: &str, _args: &serde_json::Value| {
+        Box::pin(async move {
+            if name == "delete_all_data" {
+                return Ok(GuardrailResult::Deny("Dangerous tool blocked".into()));
+            }
+            Ok(GuardrailResult::Allow)
+        })
+    })],
+    ..Default::default()
+};
+
+let options = TurnOptions {
+    guardrails: Some(guardrails),
+    ..Default::default()
+};
+
+let result = prompty::turn(&agent, Some(&inputs), Some(options)).await?;
+```
+</TabItem>
 </Tabs>
 
 ### Guardrail Checkpoints
@@ -409,6 +508,26 @@ var result = await Pipeline.TurnAsync(
 );
 ```
 </TabItem>
+<TabItem label="Rust">
+```rust
+use prompty::{TurnOptions, Steering};
+
+let steering = Steering::new();
+
+// Inject a message that will be picked up at the next iteration
+steering.send(prompty::Message::text(
+    prompty::Role::User,
+    "Actually, check Paris instead of London",
+));
+
+let options = TurnOptions {
+    steering: Some(steering),
+    ..Default::default()
+};
+
+let result = prompty::turn(&agent, Some(&inputs), Some(options)).await?;
+```
+</TabItem>
 </Tabs>
 
 At the top of each iteration, the loop calls `steering.drain()` to collect all
@@ -448,6 +567,17 @@ var result = await Pipeline.TurnAsync(
     agent, inputs, tools,
     parallelToolCalls: true
 );
+```
+</TabItem>
+<TabItem label="Rust">
+```rust
+// Uses tokio::join! for concurrent execution
+let options = TurnOptions {
+    parallel_tool_calls: Some(true),
+    ..Default::default()
+};
+
+let result = prompty::turn(&agent, Some(&inputs), Some(options)).await?;
 ```
 </TabItem>
 </Tabs>
@@ -552,6 +682,42 @@ var result = await Pipeline.TurnAsync(
     steering: steering,
     parallelToolCalls: true
 );
+```
+</TabItem>
+<TabItem label="Rust">
+```rust
+use prompty::{TurnOptions, AgentEvent, Steering, Guardrails, GuardrailResult};
+use std::sync::{Arc, atomic::{AtomicBool, Ordering}};
+
+let agent = prompty::load("agent.prompty")?;
+let cancel = Arc::new(AtomicBool::new(false));
+let steering = Steering::new();
+
+let guardrails = Guardrails {
+    input: vec![Arc::new(|_| Box::pin(async { Ok(GuardrailResult::Allow) }))],
+    output: vec![Arc::new(|_| Box::pin(async { Ok(GuardrailResult::Allow) }))],
+    tool: vec![Arc::new(|_, _| Box::pin(async { Ok(GuardrailResult::Allow) }))],
+    ..Default::default()
+};
+
+let options = TurnOptions {
+    max_iterations: Some(20),
+    events: Some(Arc::new(|event: AgentEvent| {
+        println!("[{event:?}]");
+    })),
+    cancellation_token: Some(cancel),
+    context_window: Some(50_000),
+    guardrails: Some(guardrails),
+    steering: Some(steering),
+    parallel_tool_calls: Some(true),
+    ..Default::default()
+};
+
+let result = prompty::turn(
+    &agent,
+    Some(&serde_json::json!({"question": "Plan my trip"})),
+    Some(options),
+).await?;
 ```
 </TabItem>
 </Tabs>
@@ -689,6 +855,23 @@ var service = new WeatherService();
 var tools = ToolAttribute.BindTools(agent, service);
 
 var result = await Pipeline.TurnAsync(agent, inputs, tools: tools);
+```
+</TabItem>
+<TabItem label="Rust">
+```rust
+// Register tool handlers (Rust uses register_tool_handler)
+prompty::register_tool_handler("get_weather", |args| {
+    Box::pin(async move {
+        let city = args["city"].as_str().unwrap_or("unknown");
+        let _units = args.get("units")
+            .and_then(|v| v.as_str())
+            .unwrap_or("celsius");
+        Ok(serde_json::json!(format!("72°F in {city}")))
+    })
+});
+
+let agent = prompty::load("agent.prompty")?;
+let result = prompty::turn(&agent, Some(&inputs), None).await?;
 ```
 </TabItem>
 </Tabs>
@@ -833,10 +1016,41 @@ var result = await Pipeline.TurnAsync(
 Console.WriteLine(result);
 ```
 </TabItem>
+<TabItem label="Rust">
+```rust
+use prompty::TurnOptions;
+use serde_json::json;
+
+// Register tool handlers
+prompty::register_tool_handler("get_weather", |args| {
+    Box::pin(async move {
+        let city = args["city"].as_str().unwrap_or("unknown");
+        Ok(json!(format!("72°F and sunny in {city}")))
+    })
+});
+
+prompty::register_tool_handler("get_time", |args| {
+    Box::pin(async move {
+        let tz = args["timezone"].as_str().unwrap_or("unknown");
+        Ok(json!(format!("3:42 PM in {tz}")))
+    })
+});
+
+let agent = prompty::load("agent.prompty")?;
+
+let result = prompty::turn(
+    &agent,
+    Some(&json!({"question": "What's the weather in Tokyo?"})),
+    None,
+).await?;
+
+println!("{result}");
+```
+</TabItem>
 </Tabs>
 
 <Aside type="note">
-  `bind_tools` validates that every handler name matches a `kind: "function"` tool
+  `bind_tools` validates that every handler namematches a `kind: "function"` tool
   declared in the agent's frontmatter. If you typo a name or forget a declaration,
   you get an immediate error — not a silent runtime failure when the LLM tries to
   call the tool.
@@ -892,6 +1106,25 @@ var method = typeof(MyClass).GetMethod("MyMethod")!;
 var toolDef = ToolAttribute.BuildFromMethod(method);
 Console.WriteLine(toolDef.Name);        // "MyMethod"
 Console.WriteLine(toolDef.Parameters);  // [Property { Name = "x", Kind = "string" }]
+```
+</TabItem>
+<TabItem label="Rust">
+```rust
+// Register a handler with a specific name
+prompty::register_tool_handler("get_weather", |args| {
+    Box::pin(async move {
+        let city = args["city"].as_str().unwrap_or("unknown");
+        Ok(serde_json::json!(format!("72°F in {city}")))
+    })
+});
+
+// Access tool definitions from a loaded agent
+let agent = prompty::load("agent.prompty")?;
+if let Some(tools) = &agent.tools {
+    for tool in tools {
+        println!("Tool: {} — {:?}", tool.name(), tool.description());
+    }
+}
 ```
 </TabItem>
 </Tabs>

--- a/web/src/content/docs/core-concepts/agent-mode.mdx
+++ b/web/src/content/docs/core-concepts/agent-mode.mdx
@@ -167,6 +167,44 @@ var result = await Pipeline.TurnAsync(
 Console.WriteLine(result); // "It's currently 72°F and sunny in Seattle!"
 ```
 </TabItem>
+<TabItem label="Rust">
+```rust
+use prompty::TurnOptions;
+use serde_json::json;
+
+// 1. Register tool handlers
+prompty::register_tool_handler("get_weather", |args| {
+    Box::pin(async move {
+        let city = args["city"].as_str().unwrap_or("unknown");
+        Ok(json!(format!("72°F and sunny in {city}")))
+    })
+});
+
+prompty::register_tool_handler("get_time", |args| {
+    Box::pin(async move {
+        let tz = args["timezone"].as_str().unwrap_or("unknown");
+        Ok(json!(format!("3:42 PM in {tz}")))
+    })
+});
+
+// 2. Load the agent prompt
+let agent = prompty::load("agent.prompty")?;
+
+// 3. Run the agent loop
+let options = TurnOptions {
+    max_iterations: Some(10),
+    ..Default::default()
+};
+
+let result = prompty::turn(
+    &agent,
+    Some(&json!({"question": "What's the weather in Seattle?"})),
+    Some(options),
+).await?;
+
+println!("{result}"); // "It's currently 72°F and sunny in Seattle!"
+```
+</TabItem>
 </Tabs>
 
 <Aside type="tip">
@@ -372,6 +410,34 @@ var result = await Pipeline.TurnAsync(
 );
 
 Console.WriteLine(result);
+```
+</TabItem>
+<TabItem label="Rust">
+```rust
+use prompty::TurnOptions;
+use serde_json::json;
+
+prompty::register_tool_handler("get_weather", |args| {
+    Box::pin(async move {
+        let city = args["city"].as_str().unwrap_or("unknown");
+        Ok(json!(format!("72°F and sunny in {city}")))
+    })
+});
+
+let agent = prompty::load("agent.prompty")?;
+
+let options = TurnOptions {
+    max_iterations: Some(10),
+    ..Default::default()
+};
+
+let result = prompty::turn(
+    &agent,
+    Some(&json!({"question": "What's the weather in London?"})),
+    Some(options),
+).await?;
+
+println!("{result}");
 ```
 </TabItem>
 </Tabs>

--- a/web/src/content/docs/core-concepts/connections.mdx
+++ b/web/src/content/docs/core-concepts/connections.mdx
@@ -192,6 +192,17 @@ Register the client at application startup:
     ));
     ```
   </TabItem>
+  <TabItem label="Rust">
+    ```rust
+    use serde_json::json;
+
+    prompty::register_connection("my-foundry-client", json!({
+        "kind": "key",
+        "endpoint": "https://my-resource.services.ai.azure.com/api/projects/my-project",
+        "apiKey": "...",
+    }));
+    ```
+  </TabItem>
 </Tabs>
 
 The executor looks up `"my-azure-client"` in the connection registry and uses
@@ -381,6 +392,23 @@ and complex auth logic in application code — not in YAML.
 
     // Register it by name — .prompty files reference this name
     ConnectionRegistry.Register("foundry-prod", client);
+    ```
+  </TabItem>
+  <TabItem label="Rust">
+    ```rust
+    use serde_json::json;
+
+    // Register a named connection — .prompty files reference this name
+    prompty::register_connection("foundry-prod", json!({
+        "kind": "key",
+        "endpoint": std::env::var("AZURE_ENDPOINT").unwrap(),
+        "apiKey": std::env::var("AZURE_API_KEY").unwrap(),
+    }));
+
+    // Check if a connection exists
+    if prompty::has_connection("foundry-prod") {
+        // Connection is registered and ready
+    }
     ```
   </TabItem>
 </Tabs>

--- a/web/src/content/docs/core-concepts/file-format.mdx
+++ b/web/src/content/docs/core-concepts/file-format.mdx
@@ -641,4 +641,26 @@ Run it with the Prompty runtime:
     });
     ```
   </TabItem>
+  <TabItem label="Rust">
+    ```rust
+    use serde_json::json;
+
+    prompty::register_defaults();
+    prompty_foundry::register();
+
+    // Load + render + parse + execute + process in one call
+    let inputs = json!({
+        "customerName": "Jane Doe",
+        "question": "Where is my order #12345?",
+        "orderHistory": [
+            {"id": "12345", "status": "shipped", "date": "2025-01-15"},
+            {"id": "12300", "status": "delivered", "date": "2025-01-02"},
+        ],
+    });
+    let result = prompty::invoke_from_path(
+        "customer-support.prompty",
+        Some(&inputs),
+    ).await?;
+    ```
+  </TabItem>
 </Tabs>

--- a/web/src/content/docs/core-concepts/pipeline.mdx
+++ b/web/src/content/docs/core-concepts/pipeline.mdx
@@ -315,10 +315,33 @@ The individual functions map to subsets of this pipeline:
     var output = await Pipeline.InvokeAsync("chat.prompty", inputs);
     ```
   </TabItem>
+  <TabItem label="Rust">
+    ```rust
+    use serde_json::json;
+
+    let agent = prompty::load("chat.prompty")?;
+    let inputs = json!({"firstName": "Jane", "question": "What is AI?"});
+
+    // Stage 1 only — render the template
+    let rendered = prompty::render(&agent, Some(&inputs)).await?;
+
+    // Stage 2 only — parse rendered string into messages
+    let messages = prompty::parse(&agent, &rendered).await?;
+
+    // Stages 1 + 2 — render, parse, and expand threads
+    let messages = prompty::prepare(&agent, Some(&inputs)).await?;
+
+    // Stages 3 + 4 — execute LLM call and process response
+    let result = prompty::run(&agent, &messages).await?;
+
+    // Full pipeline — load + prepare + run
+    let output = prompty::invoke_from_path("chat.prompty", Some(&inputs)).await?;
+    ```
+  </TabItem>
 </Tabs>
 
 <Aside type="tip">
-  Most users only need **`invoke()`** — it handles the full pipeline from file to
+  Most users only need **`invoke()`**— it handles the full pipeline from file to
   result. Use the granular functions when you need to inspect or modify intermediate
   outputs (e.g., editing messages before sending them to the LLM).
 </Aside>
@@ -424,6 +447,26 @@ and the pipeline looks them up at runtime.
     InvokerRegistry.RegisterProcessor("my-provider", new MyProcessor());
     ```
   </TabItem>
+  <TabItem label="Rust">
+    Rust uses **explicit registration** via function calls at startup. Built-in
+    renderers and parsers auto-register when `prompty::register_defaults()` is
+    called. Provider crates register their executors and processors via their
+    own `register()` function.
+
+    ```rust
+    // Register built-in renderers + parsers
+    prompty::register_defaults();
+
+    // Provider crates register on call:
+    prompty_openai::register();    // → registers "openai" executor + processor
+    prompty_foundry::register();   // → registers "foundry" executor + processor
+    prompty_anthropic::register(); // → registers "anthropic" executor + processor
+
+    // Manual registration for custom implementations:
+    prompty::register_executor("my-provider", MyExecutor::new());
+    prompty::register_processor("my-provider", MyProcessor::new());
+    ```
+  </TabItem>
 </Tabs>
 
 ### Registration groups
@@ -510,6 +553,40 @@ Each protocol defines `sync` and `async` methods. Here's an example custom execu
     }
     ```
   </TabItem>
+  <TabItem label="Rust">
+    ```rust
+    use prompty::types::Message;
+    use async_trait::async_trait;
+
+    pub struct AnthropicExecutor;
+
+    #[async_trait]
+    impl prompty::Executor for AnthropicExecutor {
+        async fn execute(
+            &self,
+            agent: &prompty::Prompty,
+            messages: &[Message],
+        ) -> Result<serde_json::Value, Box<dyn std::error::Error>> {
+            // Call your LLM API here
+            todo!()
+        }
+    }
+
+    pub struct AnthropicProcessor;
+
+    #[async_trait]
+    impl prompty::Processor for AnthropicProcessor {
+        async fn process(
+            &self,
+            agent: &prompty::Prompty,
+            response: serde_json::Value,
+        ) -> Result<serde_json::Value, Box<dyn std::error::Error>> {
+            // Extract content from the API response
+            todo!()
+        }
+    }
+    ```
+  </TabItem>
 </Tabs>
 
 ### 2. Register the implementation
@@ -555,6 +632,23 @@ Each protocol defines `sync` and `async` methods. Here's an example custom execu
         .AddAnthropic();
     ```
   </TabItem>
+  <TabItem label="Rust">
+    Register at startup via a `register()` function in your crate:
+
+    ```rust
+    pub fn register() {
+        prompty::register_executor("anthropic", AnthropicExecutor);
+        prompty::register_processor("anthropic", AnthropicProcessor);
+    }
+    ```
+
+    Then call it at application startup:
+
+    ```rust
+    prompty::register_defaults();
+    my_crate::register();
+    ```
+  </TabItem>
 </Tabs>
 
 ### 3. Use it
@@ -596,6 +690,17 @@ model:
 
     var result = await Pipeline.InvokeAsync("claude-chat.prompty",
         new() { ["question"] = "Hello!" });
+    ```
+  </TabItem>
+  <TabItem label="Rust">
+    ```rust
+    use serde_json::json;
+
+    prompty::register_defaults();
+    prompty_anthropic::register();
+
+    let inputs = json!({"question": "Hello!"});
+    let result = prompty::invoke_from_path("claude-chat.prompty", Some(&inputs)).await?;
     ```
   </TabItem>
 </Tabs>

--- a/web/src/content/docs/core-concepts/providers.mdx
+++ b/web/src/content/docs/core-concepts/providers.mdx
@@ -308,6 +308,40 @@ public class MyProcessor : IProcessor
 }
 ```
 </TabItem>
+  <TabItem label="Rust">
+```rust
+use prompty::types::Message;
+use async_trait::async_trait;
+
+pub struct MyExecutor;
+
+#[async_trait]
+impl prompty::Executor for MyExecutor {
+    async fn execute(
+        &self,
+        agent: &prompty::Prompty,
+        messages: &[Message],
+    ) -> Result<serde_json::Value, Box<dyn std::error::Error>> {
+        // Call your LLM API here
+        todo!()
+    }
+}
+
+pub struct MyProcessor;
+
+#[async_trait]
+impl prompty::Processor for MyProcessor {
+    async fn process(
+        &self,
+        agent: &prompty::Prompty,
+        response: serde_json::Value,
+    ) -> Result<serde_json::Value, Box<dyn std::error::Error>> {
+        // Extract content from the API response
+        todo!()
+    }
+}
+```
+</TabItem>
 </Tabs>
 
 ### 2. Register Your Provider
@@ -351,6 +385,15 @@ new PromptyBuilder()
 // Or register directly
 InvokerRegistry.RegisterExecutor("myprovider", new MyExecutor());
 InvokerRegistry.RegisterProcessor("myprovider", new MyProcessor());
+```
+</TabItem>
+  <TabItem label="Rust">
+Register at startup via function calls:
+
+```rust
+prompty::register_defaults();
+prompty::register_executor("myprovider", MyExecutor);
+prompty::register_processor("myprovider", MyProcessor);
 ```
 </TabItem>
 </Tabs>

--- a/web/src/content/docs/core-concepts/responses-api.mdx
+++ b/web/src/content/docs/core-concepts/responses-api.mdx
@@ -143,6 +143,9 @@ var result = await Pipeline.InvokeAsync("my-prompt.prompty",
 Console.WriteLine(result); // "Hi there! How can I help?"
 ```
 </TabItem>
+<TabItem label="Rust">
+Rust does not yet support the OpenAI Responses API. Use the standard Chat Completions API instead. Contributions welcome!
+</TabItem>
 </Tabs>
 
 ---
@@ -320,6 +323,9 @@ var result = await Pipeline.TurnAsync(
 Console.WriteLine(result); // "It's currently 72°F and sunny in Seattle!"
 ```
 </TabItem>
+<TabItem label="Rust">
+Rust does not yet support the OpenAI Responses API. Use the standard Chat Completions API instead. Contributions welcome!
+</TabItem>
 </Tabs>
 
 ### How Tool Calls Work with the Responses API
@@ -436,9 +442,12 @@ Console.WriteLine(result.GetProperty("temperature"));  // 62
 Console.WriteLine(result.GetProperty("conditions"));   // "Partly cloudy"
 ```
 </TabItem>
+<TabItem label="Rust">
+Rust does not yet support the OpenAI Responses API. Use the standard Chat Completions API instead. Contributions welcome!
+</TabItem>
 </Tabs>
 
-The runtime sends structured output as `text.format` instead of `response_format`:
+The runtime sends structured output as `text.format`instead of `response_format`:
 
 ```json title="Responses API structured output"
 {

--- a/web/src/content/docs/core-concepts/streaming.mdx
+++ b/web/src/content/docs/core-concepts/streaming.mdx
@@ -98,10 +98,20 @@ user:
     agent.Model.Options.AdditionalProperties["stream"] = true;
     ```
   </TabItem>
+  <TabItem label="Rust">
+    ```rust
+    // Streaming is configured in the .prompty file via:
+    //   options:
+    //     additionalProperties:
+    //       stream: true
+    // The Rust runtime respects this setting at execution time.
+    let agent = prompty::load("chat.prompty")?;
+    ```
+  </TabItem>
 </Tabs>
 
 <Aside type="tip">
-  The `additionalProperties` dict on `ModelOptions` passes through to the
+  The `additionalProperties` dict on `ModelOptions`passes through to the
   underlying SDK call. Any key the SDK accepts (like `stream`, `logprobs`,
   `n`) can be set here.
 </Aside>
@@ -195,6 +205,26 @@ user:
         }
     }
     Console.WriteLine();
+    ```
+  </TabItem>
+  <TabItem label="Rust">
+    ```rust
+    use prompty::{StreamChunk, PromptyStream, consume_stream_chunks};
+
+    let agent = prompty::load("chat.prompty")?;
+    let inputs = serde_json::json!({"question": "Tell me a joke"});
+    let messages = prompty::prepare(&agent, Some(&inputs)).await?;
+    let result = prompty::run(&agent, &messages).await?;
+
+    // Process streaming chunks
+    let stream = prompty::from_structured_value::<PromptyStream>(&result)?;
+    consume_stream_chunks(stream, |chunk| match chunk {
+        StreamChunk::Text(text) => print!("{text}"),
+        StreamChunk::Thinking(thought) => print!("[thinking] {thought}"),
+        StreamChunk::Tool(tc) => println!("[tool] {}: {}", tc.name, tc.arguments),
+        StreamChunk::Error(err) => eprintln!("[error] {err}"),
+    }).await;
+    println!();
     ```
   </TabItem>
 </Tabs>

--- a/web/src/content/docs/core-concepts/structured-output.mdx
+++ b/web/src/content/docs/core-concepts/structured-output.mdx
@@ -174,6 +174,20 @@ the raw JSON for efficient type casting.
     }
     ```
   </TabItem>
+  <TabItem label="Rust">
+    ```rust
+    // The outputSchema in the .prompty file is automatically converted
+    // to OpenAI's response_format parameter. The result comes back as
+    // a parsed serde_json::Value matching the schema.
+    let inputs = serde_json::json!({"city": "Seattle"});
+    let result = prompty::invoke_from_path("weather.prompty", Some(&inputs)).await?;
+
+    // result is a serde_json::Value — use like a JSON object
+    println!("{}", result["city"]);         // "Seattle"
+    println!("{}", result["temperature"]);  // 62
+    println!("{}", result["conditions"]);   // "Partly cloudy"
+    ```
+  </TabItem>
 </Tabs>
 
 ---
@@ -305,10 +319,31 @@ round-trip.
         new() { ["city"] = "Seattle" });
     ```
   </TabItem>
+  <TabItem label="Rust">
+    ```rust
+    use serde::Deserialize;
+
+    #[derive(Deserialize, Debug)]
+    struct Weather {
+        city: String,
+        temperature: i32,
+        conditions: String,
+    }
+
+    let inputs = serde_json::json!({"city": "Seattle"});
+    let result = prompty::invoke_from_path("weather.prompty", Some(&inputs)).await?;
+
+    // Deserialize the serde_json::Value into a typed struct
+    let weather: Weather = serde_json::from_value(result)?;
+
+    println!("{}", weather.city);         // "Seattle"
+    println!("{}", weather.temperature);  // 62
+    ```
+  </TabItem>
 </Tabs>
 
 <Aside type="note">
-  `cast()` uses the raw JSON string stored inside `StructuredResult` — it does
+  `cast()` uses the raw JSON stringstored inside `StructuredResult` — it does
   **not** serialize back to JSON from the dict and then re-parse. This is the
   fastest possible path from LLM response to your typed object.
 </Aside>

--- a/web/src/content/docs/core-concepts/tools.mdx
+++ b/web/src/content/docs/core-concepts/tools.mdx
@@ -341,6 +341,23 @@ response.
     var result = await Pipeline.TurnAsync(agent, inputs, tools: tools);
     ```
   </TabItem>
+  <TabItem label="Rust">
+    ```rust
+    use serde_json::json;
+
+    prompty::register_tool_handler("get_weather", |args| {
+        Box::pin(async move {
+            let city = args["city"].as_str().unwrap_or("unknown");
+            let units = args["units"].as_str().unwrap_or("celsius");
+            Ok(json!(format!("72°F and sunny in {city}")))
+        })
+    });
+
+    let agent = prompty::load("agent.prompty")?;
+    let inputs = json!({"question": "Weather in Seattle?"});
+    let result = prompty::turn(&agent, Some(&inputs), None).await?;
+    ```
+  </TabItem>
 </Tabs>
 
 <Tabs>
@@ -378,6 +395,16 @@ response.
         agent, inputs, tools: tools, maxIterations: 10);
 
     Console.WriteLine(result);
+    ```
+  </TabItem>
+  <TabItem label="Rust">
+    ```rust
+    use serde_json::json;
+
+    let agent = prompty::load("agent.prompty")?;
+    let inputs = json!({"question": "Weather in Seattle?"});
+    let result = prompty::turn(&agent, Some(&inputs), None).await?;
+    println!("{result}");
     ```
   </TabItem>
 </Tabs>
@@ -463,6 +490,24 @@ into the wire format the LLM expects (typically an OpenAI-style function definit
     ToolDispatch.RegisterToolHandler("my_provider", new MyToolHandler());
     ```
   </TabItem>
+  <TabItem label="Rust">
+    ```rust
+    use serde_json::json;
+
+    fn my_tool_projector(tool: &prompty::Tool) -> serde_json::Value {
+        json!({
+            "type": "function",
+            "function": {
+                "name": tool.name,
+                "description": tool.description,
+                "parameters": { /* ... */ },
+            }
+        })
+    }
+
+    prompty::register_tool("my_provider", my_tool_projector);
+    ```
+  </TabItem>
 </Tabs>
 
 When the executor sends tools to the LLM, it calls each tool's registered
@@ -519,6 +564,19 @@ returns the result string.
     // Parse LLM-returned JSON arguments into a dictionary
     var args = ToolDispatch.ParseArguments(jsonArgs);
     var city = args["city"]?.ToString() ?? "unknown";
+    ```
+  </TabItem>
+  <TabItem label="Rust">
+    ```rust
+    use serde_json::json;
+
+    prompty::register_tool_handler("my_provider", |args| {
+        Box::pin(async move {
+            // Use the tool's connection, options, etc.
+            let result = call_my_service(&args).await?;
+            Ok(json!(result))
+        })
+    });
     ```
   </TabItem>
 </Tabs>

--- a/web/src/content/docs/core-concepts/tracing.mdx
+++ b/web/src/content/docs/core-concepts/tracing.mdx
@@ -96,6 +96,18 @@ like — every trace event is dispatched to **all** registered backends.
     new PromptyTracer().Register();
     ```
   </TabItem>
+  <TabItem label="Rust">
+    ```rust
+    use prompty::{Tracer, PromptyTracer, console_tracer};
+
+    // JSON file tracer — writes structured traces to disk
+    let pt = PromptyTracer::new("./traces");
+    Tracer::register("json", pt.tracer());
+
+    // Console tracer — prints to stdout
+    Tracer::register("console", console_tracer);
+    ```
+  </TabItem>
 </Tabs>
 
 <Aside type="tip">
@@ -150,6 +162,20 @@ other traced functions (including Prompty's built-in pipeline), they appear as
     });
     ```
   </TabItem>
+  <TabItem label="Rust">
+    ```rust
+    use prompty::trace_async;
+    use serde_json::json;
+
+    let result = trace_async("my_business_logic", json!({"query": &query}), async {
+        let output = prompty::invoke_from_path(
+            "search.prompty",
+            Some(&json!({"q": &query})),
+        ).await?;
+        Ok(output)
+    }).await;
+    ```
+  </TabItem>
 </Tabs>
 
 The decorator automatically captures:
@@ -199,9 +225,17 @@ one `.tracy` file per top-level trace to the specified output directory.
     new PromptyTracer().Register();
     ```
   </TabItem>
+  <TabItem label="Rust">
+    ```rust
+    use prompty::{Tracer, PromptyTracer};
+
+    let tracer = PromptyTracer::new("./traces");
+    Tracer::register("json", tracer.tracer());
+    ```
+  </TabItem>
 </Tabs>
 
-Each `.tracy` file contains structured JSON with the full trace tree — every
+Each `.tracy` filecontains structured JSON with the full trace tree — every
 span, its duration, inputs, outputs, and any nested child spans. These files
 are human-readable and easy to inspect or post-process.
 
@@ -244,6 +278,15 @@ and more.
     OTelTracer.Register();
     ```
   </TabItem>
+  <TabItem label="Rust">
+    ```rust
+    #[cfg(feature = "otel")]
+    {
+        prompty::init_otel_stdout();
+        prompty::Tracer::register("otel", prompty::otel_tracer());
+    }
+    ```
+  </TabItem>
 </Tabs>
 
 <Aside type="caution">
@@ -263,6 +306,11 @@ and more.
       ```bash
       dotnet add package Prompty.Core --prerelease
       # OTel support is built into Prompty.Core
+      ```
+    </TabItem>
+    <TabItem label="Rust">
+      ```bash
+      cargo add prompty --features otel
       ```
     </TabItem>
   </Tabs>
@@ -317,6 +365,25 @@ production monitoring and console output for local debugging:
 
     // Debugging: also write .tracy files
     new PromptyTracer().Register();
+    ```
+  </TabItem>
+  <TabItem label="Rust">
+    ```rust
+    use prompty::{Tracer, PromptyTracer, console_tracer};
+
+    // Production: send to OTel collector
+    #[cfg(feature = "otel")]
+    {
+        prompty::init_otel_stdout();
+        Tracer::register("otel", prompty::otel_tracer());
+    }
+
+    // Development: also log to console
+    Tracer::register("console", console_tracer);
+
+    // Debugging: also write .tracy files
+    let pt = PromptyTracer::new("./traces");
+    Tracer::register("json", pt.tracer());
     ```
   </TabItem>
 </Tabs>
@@ -429,6 +496,35 @@ When the span ends, the backend should flush or finalize.
 
     // Register it
     Tracer.Add("my_backend", spanName => new MyTracerSpan(spanName));
+    ```
+  </TabItem>
+  <TabItem label="Rust">
+    In Rust, a tracer factory is a function that receives a span name and
+    returns a `(key, value)` callback:
+
+    ```rust
+    use prompty::Tracer;
+    use std::collections::HashMap;
+    use std::sync::{Arc, Mutex};
+
+    fn my_tracer(name: &str) -> Box<dyn Fn(&str, &serde_json::Value) + Send + Sync> {
+        let span_data = Arc::new(Mutex::new(HashMap::new()));
+        span_data.lock().unwrap().insert(
+            "name".to_string(),
+            serde_json::json!(name),
+        );
+
+        let data = span_data.clone();
+        Box::new(move |key: &str, value: &serde_json::Value| {
+            if key == "__end__" {
+                println!("Span complete: {:?}", data.lock().unwrap());
+                return;
+            }
+            data.lock().unwrap().insert(key.to_string(), value.clone());
+        })
+    }
+
+    Tracer::register("my_backend", my_tracer);
     ```
   </TabItem>
 </Tabs>
@@ -555,10 +651,43 @@ A practical example — post completed spans to an HTTP endpoint:
     Tracer.Add("webhook", name => new WebhookTracerSpan(name));
     ```
   </TabItem>
+  <TabItem label="Rust">
+    ```rust
+    use prompty::Tracer;
+    use std::collections::HashMap;
+    use std::sync::{Arc, Mutex};
+
+    fn webhook_tracer(name: &str) -> Box<dyn Fn(&str, &serde_json::Value) + Send + Sync> {
+        let span = Arc::new(Mutex::new(HashMap::from([
+            ("name".into(), serde_json::json!(name)),
+            ("started_at".into(), serde_json::json!(chrono::Utc::now().to_rfc3339())),
+        ])));
+
+        let data = span.clone();
+        Box::new(move |key: &str, value: &serde_json::Value| {
+            if key == "__end__" {
+                let mut d = data.lock().unwrap();
+                d.insert("ended_at".into(), serde_json::json!(chrono::Utc::now().to_rfc3339()));
+                let json = serde_json::to_string(&*d).unwrap_or_default();
+                // Fire-and-forget POST — never block the pipeline
+                let _ = reqwest::blocking::Client::new()
+                    .post("https://example.com/traces")
+                    .header("Content-Type", "application/json")
+                    .body(json)
+                    .send();
+                return;
+            }
+            data.lock().unwrap().insert(key.to_string(), value.clone());
+        })
+    }
+
+    Tracer::register("webhook", webhook_tracer);
+    ```
+  </TabItem>
 </Tabs>
 
 <Aside type="caution">
-  Backends **must not block the pipeline**. If your backend does I/O (HTTP,
+  Backends **must not block the pipeline**.If your backend does I/O (HTTP,
   database, file writes), catch all exceptions and consider buffering or
   flushing asynchronously. A failing backend must never cause the pipeline to
   fail.
@@ -642,6 +771,14 @@ default state is already off.
     var agent = PromptyLoader.Load("my-prompt.prompty");
     var result = await Pipeline.InvokeAsync(agent,
         new() { ["query"] = "hello" });
+    // No traces produced — zero overhead
+    ```
+  </TabItem>
+  <TabItem label="Rust">
+    ```rust
+    // No Tracer::register() calls → tracing is a no-op
+    let inputs = serde_json::json!({"query": "hello"});
+    let result = prompty::invoke_from_path("my-prompt.prompty", Some(&inputs)).await?;
     // No traces produced — zero overhead
     ```
   </TabItem>

--- a/web/src/content/docs/getting-started/index.mdx
+++ b/web/src/content/docs/getting-started/index.mdx
@@ -72,6 +72,11 @@ renders, parses, and executes these files.
       C# packages are in **alpha preview**. Install with `--prerelease` to get the latest version.
     </Aside>
   </TabItem>
+  <TabItem label="Rust">
+    ```bash
+    cargo add prompty prompty-openai
+    ```
+  </TabItem>
 </Tabs>
 
 ## Write Your First `.prompty` File
@@ -137,6 +142,25 @@ Say hello to {{userName}} and ask how their day is going.
     // "Hello Jane! 👋 How's your day going so far?"
     ```
   </TabItem>
+  <TabItem label="Rust">
+    ```rust
+    use prompty;
+    use prompty_openai;
+    use serde_json::json;
+
+    // Register providers
+    prompty::register_defaults();
+    prompty_openai::register();
+
+    // All-in-one: load → render → parse → execute → process
+    let result = prompty::invoke_from_path(
+        "greeting.prompty",
+        Some(&json!({ "userName": "Jane" })),
+    ).await?;
+    println!("{result}");
+    // "Hello Jane! 👋 How's your day going so far?"
+    ```
+  </TabItem>
 </Tabs>
 
 ## Step-by-Step Pipeline
@@ -184,6 +208,27 @@ For more control, use the pipeline stages individually:
     var result = await Pipeline.ProcessAsync(agent, response);
     ```
   </TabItem>
+  <TabItem label="Rust">
+    ```rust
+    use prompty;
+    use prompty_openai;
+    use serde_json::json;
+
+    prompty::register_defaults();
+    prompty_openai::register();
+
+    // 1. Load the .prompty file → typed agent
+    let agent = prompty::load("greeting.prompty")?;
+
+    // 2. Render template + parse → messages
+    let messages = prompty::prepare(
+        &agent, Some(&json!({ "userName": "Jane" }))
+    ).await?;
+
+    // 3. Call the LLM + process → clean result
+    let result = prompty::run(&agent, &messages).await?;
+    ```
+  </TabItem>
 </Tabs>
 
 ## Environment Variables
@@ -210,6 +255,28 @@ Here's a full, tested example you can copy and run:
   </TabItem>
   <TabItem label="C#">
     <Code code={csBasic} lang="csharp" title="ChatBasic.cs" />
+  </TabItem>
+  <TabItem label="Rust">
+    ```rust
+    // chat_basic.rs
+    use prompty;
+    use prompty_openai;
+    use serde_json::json;
+
+    #[tokio::main]
+    async fn main() -> Result<(), Box<dyn std::error::Error>> {
+        prompty::register_defaults();
+        prompty_openai::register();
+
+        let result = prompty::invoke_from_path(
+            "greeting.prompty",
+            Some(&json!({ "userName": "Jane" })),
+        ).await?;
+
+        println!("{result}");
+        Ok(())
+    }
+    ```
   </TabItem>
 </Tabs>
 

--- a/web/src/content/docs/getting-started/whats-new.mdx
+++ b/web/src/content/docs/getting-started/whats-new.mdx
@@ -93,6 +93,28 @@ var result = await Pipeline.TurnAsync(
     tools: new() { ["get_weather"] = GetWeather });
 ```
 </TabItem>
+<TabItem label="Rust">
+```rust
+use prompty::TurnOptions;
+use serde_json::json;
+
+prompty::register_tool_handler("get_weather", |args| {
+    Box::pin(async move {
+        let city = args["city"].as_str().unwrap_or("unknown");
+        Ok(json!(format!("72°F in {city}")))
+    })
+});
+
+let result = prompty::turn_from_path(
+    "agent.prompty",
+    Some(&json!({ "question": "Weather in Seattle?" })),
+    Some(TurnOptions {
+        max_iterations: Some(10),
+        ..Default::default()
+    }),
+).await?;
+```
+</TabItem>
 </Tabs>
 
 Without tools, `turn()` behaves identically to `invoke()` — the only difference
@@ -114,14 +136,15 @@ turn 1
 
 ## Three Runtimes, One File Format
 
-v2 adds **TypeScript** and **C#** runtimes alongside the existing Python runtime.
-All three share the same `.prompty` file format and public API:
+v2 adds **TypeScript** and **C#** runtimes alongside the existing Python runtime,
+and introduces a new **Rust** runtime.
+All four share the same `.prompty` file format and public API:
 
-| | Python | TypeScript | C# |
-|---|---|---|---|
-| Package | `prompty` | `@prompty/core` | `Prompty.Core` |
-| Providers | `prompty[openai]` | `@prompty/openai` | `Prompty.OpenAI` |
-| Install | `uv pip install` | `npm install` | `dotnet add package` |
+| | Python | TypeScript | C# | Rust |
+|---|---|---|---|---|
+| Package | `prompty` | `@prompty/core` | `Prompty.Core` | `prompty` |
+| Providers | `prompty[openai]` | `@prompty/openai` | `Prompty.OpenAI` | `prompty-openai` |
+| Install | `uv pip install` | `npm install` | `dotnet add package` | `cargo add` |
 
 ## Other Improvements
 

--- a/web/src/content/docs/how-to/agent-tool-calling.mdx
+++ b/web/src/content/docs/how-to/agent-tool-calling.mdx
@@ -96,6 +96,23 @@ User message
     }
     ```
   </TabItem>
+  <TabItem label="Rust">
+    ```rust
+    prompty::register_tool_handler("get_weather", |args| {
+        Box::pin(async move {
+            let city = args["city"].as_str().unwrap_or("unknown");
+            Ok(serde_json::json!(format!("72°F and sunny in {city}")))
+        })
+    });
+
+    prompty::register_tool_handler("get_time", |args| {
+        Box::pin(async move {
+            let _tz = args["timezone"].as_str().unwrap_or("UTC");
+            Ok(serde_json::json!(chrono::Utc::now().to_rfc3339()))
+        })
+    });
+    ```
+  </TabItem>
 </Tabs>
 
 ---
@@ -256,6 +273,40 @@ user:
     Console.WriteLine(result);
     ```
   </TabItem>
+  <TabItem label="Rust">
+    ```rust
+    use serde_json::json;
+    use prompty::TurnOptions;
+
+    #[tokio::main]
+    async fn main() -> Result<(), Box<dyn std::error::Error>> {
+        prompty::register_defaults();
+        prompty_openai::register();
+
+        prompty::register_tool_handler("get_weather", |args| {
+            Box::pin(async move {
+                let city = args["city"].as_str().unwrap_or("unknown");
+                Ok(json!(format!("72°F and sunny in {city}")))
+            })
+        });
+
+        prompty::register_tool_handler("get_time", |args| {
+            Box::pin(async move {
+                let _tz = args["timezone"].as_str().unwrap_or("UTC");
+                Ok(json!(chrono::Utc::now().to_rfc3339()))
+            })
+        });
+
+        let result = prompty::turn_from_path(
+            "agent.prompty",
+            Some(&json!({ "question": "What's the weather in Seattle and the time in Tokyo?" })),
+            Some(TurnOptions { max_iterations: Some(10), ..Default::default() }),
+        ).await?;
+        println!("{result}");
+        Ok(())
+    }
+    ```
+  </TabItem>
 </Tabs>
 
 ---
@@ -349,6 +400,32 @@ If your tools call external APIs, use async functions to avoid blocking:
     <Aside type="tip">
       In C#, `[Tool]` methods can return `Task&lt;string&gt;` for async operations.
       The runtime handles both sync and async handlers seamlessly.
+    </Aside>
+  </TabItem>
+  <TabItem label="Rust">
+    ```rust
+    prompty::register_tool_handler("get_weather", |args| {
+        Box::pin(async move {
+            let city = args["city"].as_str().unwrap_or("unknown");
+            let client = reqwest::Client::new();
+            let resp = client
+                .get(format!("https://api.weather.com/v1/{city}"))
+                .send()
+                .await
+                .map_err(|e| prompty::InvokerError::ExecutionError(e.to_string()))?;
+            let data: serde_json::Value = resp.json().await
+                .map_err(|e| prompty::InvokerError::ExecutionError(e.to_string()))?;
+            Ok(serde_json::json!(format!(
+                "{}°F, {}",
+                data["temp"], data["condition"]
+            )))
+        })
+    });
+    ```
+
+    <Aside type="tip">
+      In Rust, all tool handlers are inherently async — they return a pinned
+      future. Use `.await` freely inside the closure.
     </Aside>
   </TabItem>
 </Tabs>
@@ -532,6 +609,40 @@ user:
     );
     ```
   </TabItem>
+  <TabItem label="Rust">
+    ```rust
+    use serde_json::json;
+    use prompty::TurnOptions;
+
+    prompty::register_tool_handler("search_docs", |args| {
+        Box::pin(async move {
+            let query = args["query"].as_str().unwrap_or("");
+            let limit = args["limit"].as_i64().unwrap_or(5);
+            Ok(json!(format!("Found {limit} results for '{query}'")))
+        })
+    });
+
+    prompty::register_tool_handler("get_user", |args| {
+        Box::pin(async move {
+            let email = args["email"].as_str().unwrap_or("");
+            Ok(json!({"name": "Jane Doe", "email": email, "role": "Engineer"}))
+        })
+    });
+
+    prompty::register_tool_handler("send_email", |args| {
+        Box::pin(async move {
+            let to = args["to"].as_str().unwrap_or("");
+            Ok(json!(format!("Email sent to {to}")))
+        })
+    });
+
+    let result = prompty::turn_from_path(
+        "research-agent.prompty",
+        Some(&json!({ "request": "Find docs about onboarding and email a summary to jane@example.com" })),
+        Some(TurnOptions { max_iterations: Some(10), ..Default::default() }),
+    ).await?;
+    ```
+  </TabItem>
 </Tabs>
 
 ---
@@ -622,6 +733,28 @@ user:
     }
     ```
   </TabItem>
+  <TabItem label="Rust">
+    ```rust
+    use serde_json::json;
+    use prompty::TurnOptions;
+
+    prompty::register_tool_handler("get_weather", |args| {
+        Box::pin(async move {
+            let city = args["city"].as_str().unwrap_or("unknown");
+            Ok(json!(format!("72°F and sunny in {city}")))
+        })
+    });
+
+    match prompty::turn_from_path(
+        "agent.prompty",
+        Some(&json!({ "question": "Weather?" })),
+        Some(TurnOptions { max_iterations: Some(10), ..Default::default() }),
+    ).await {
+        Ok(result) => println!("{result}"),
+        Err(e) => eprintln!("Agent error: {e}"),
+    }
+    ```
+  </TabItem>
 </Tabs>
 
 **Common pitfalls:**
@@ -653,6 +786,35 @@ A full, tested example you can copy and run:
   </TabItem>
   <TabItem label="C#">
     <Code code={csAgent} lang="csharp" title="AgentToolCalling.cs" />
+  </TabItem>
+  <TabItem label="Rust">
+    ```rust
+    use serde_json::json;
+    use prompty::TurnOptions;
+
+    #[tokio::main]
+    async fn main() -> Result<(), Box<dyn std::error::Error>> {
+        prompty::register_defaults();
+        prompty_openai::register();
+
+        // Register tool handlers
+        prompty::register_tool_handler("get_weather", |args| {
+            Box::pin(async move {
+                let city = args["city"].as_str().unwrap_or("unknown");
+                Ok(json!(format!("72°F and sunny in {city}")))
+            })
+        });
+
+        // Run the agent loop — tools are called automatically
+        let result = prompty::turn_from_path(
+            "agent.prompty",
+            Some(&json!({ "question": "What's the weather in Seattle?" })),
+            Some(TurnOptions { max_iterations: Some(10), ..Default::default() }),
+        ).await?;
+        println!("{result}");
+        Ok(())
+    }
+    ```
   </TabItem>
 </Tabs>
 

--- a/web/src/content/docs/how-to/anthropic.mdx
+++ b/web/src/content/docs/how-to/anthropic.mdx
@@ -28,6 +28,11 @@ import { Aside, Tabs, TabItem } from '@astrojs/starlight/components';
     dotnet add package Prompty.Anthropic --prerelease
     ```
   </TabItem>
+  <TabItem label="Rust">
+    ```bash
+    cargo add prompty prompty-anthropic
+    ```
+  </TabItem>
 </Tabs>
 
 You also need an [Anthropic API key](https://console.anthropic.com/settings/keys).
@@ -117,6 +122,24 @@ ANTHROPIC_API_KEY=sk-ant-your-key-here
     Console.WriteLine(result);
     ```
   </TabItem>
+  <TabItem label="Rust">
+    ```rust
+    use serde_json::json;
+
+    #[tokio::main]
+    async fn main() -> Result<(), Box<dyn std::error::Error>> {
+        prompty::register_defaults();
+        prompty_anthropic::register();
+
+        let result = prompty::invoke_from_path(
+            "anthropic-chat.prompty",
+            Some(&json!({ "topic": "quantum computing" })),
+        ).await?;
+        println!("{result}");
+        Ok(())
+    }
+    ```
+  </TabItem>
 </Tabs>
 
 ---
@@ -168,6 +191,30 @@ If you need more control, use the individual pipeline stages:
     // Execute + process → final result
     var result = await Pipeline.RunAsync(agent, messages);
     Console.WriteLine(result);
+    ```
+  </TabItem>
+  <TabItem label="Rust">
+    ```rust
+    use serde_json::json;
+
+    #[tokio::main]
+    async fn main() -> Result<(), Box<dyn std::error::Error>> {
+        prompty::register_defaults();
+        prompty_anthropic::register();
+
+        // Load the prompt
+        let agent = prompty::load("anthropic-chat.prompty")?;
+
+        // Render + parse → message list (no LLM call)
+        let inputs = json!({ "topic": "quantum computing" });
+        let messages = prompty::prepare(&agent, Some(&inputs)).await?;
+        println!("{messages:?}"); // inspect before sending
+
+        // Execute + process → final result
+        let result = prompty::run(&agent, &messages).await?;
+        println!("{result}");
+        Ok(())
+    }
     ```
   </TabItem>
 </Tabs>

--- a/web/src/content/docs/how-to/cookbook.mdx
+++ b/web/src/content/docs/how-to/cookbook.mdx
@@ -62,6 +62,14 @@ user:
     });
     ```
   </TabItem>
+  <TabItem label="Rust">
+    ```rust
+    let agent = prompty::load("basic-chat.prompty")?;
+    let inputs = serde_json::json!({ "question": "What is quantum computing?" });
+    let messages = prompty::prepare(&agent, Some(&inputs)).await?;
+    let result = prompty::run(&agent, &messages).await?;
+    ```
+  </TabItem>
 </Tabs>
 
 ---
@@ -112,6 +120,12 @@ user:
     });
     ```
   </TabItem>
+  <TabItem label="Rust">
+    ```rust
+    let inputs = serde_json::json!({ "text": "The food was cold and bland." });
+    let result = prompty::invoke_from_path("few-shot.prompty", Some(&inputs)).await?;
+    ```
+  </TabItem>
 </Tabs>
 
 ---
@@ -160,6 +174,12 @@ user:
         ["text"] = article,
         ["length"] = "medium"
     });
+    ```
+  </TabItem>
+  <TabItem label="Rust">
+    ```rust
+    let inputs = serde_json::json!({ "text": article, "length": "medium" });
+    let result = prompty::invoke_from_path("summarize.prompty", Some(&inputs)).await?;
     ```
   </TabItem>
 </Tabs>
@@ -215,11 +235,17 @@ user:
     });
     ```
   </TabItem>
+  <TabItem label="Rust">
+    ```rust
+    let inputs = serde_json::json!({ "code": my_code, "language": "python" });
+    let result = prompty::invoke_from_path("code-review.prompty", Some(&inputs)).await?;
+    ```
+  </TabItem>
 </Tabs>
 
 ---
 
-## 5. Data Extraction (Structured Output)
+## 5. Data Extraction(Structured Output)
 
 Uses `outputs` to constrain the LLM to return JSON matching a schema.
 
@@ -278,9 +304,16 @@ user:
     });
     ```
   </TabItem>
+  <TabItem label="Rust">
+    ```rust
+    let inputs = serde_json::json!({ "text": "Jane Doe is a PM at Microsoft in Redmond." });
+    let data = prompty::invoke_from_path("extract-entities.prompty", Some(&inputs)).await?;
+    // data is a parsed serde_json::Value: {"name": "Jane Doe", "company": "Microsoft", ...}
+    ```
+  </TabItem>
 </Tabs>
 
-The `outputs` block generates an OpenAI `response_format` constraint — the model must return valid JSON matching the schema.
+The `outputs` blockgenerates an OpenAI `response_format` constraint — the model must return valid JSON matching the schema.
 
 ---
 
@@ -343,9 +376,22 @@ user:
     });
     ```
   </TabItem>
+  <TabItem label="Rust">
+    ```rust
+    let history = serde_json::json!([
+        {"role": "user", "content": "What is Python?"},
+        {"role": "assistant", "content": "A programming language."},
+    ]);
+    let inputs = serde_json::json!({
+        "question": "What about Java?",
+        "conversation": history,
+    });
+    let result = prompty::invoke_from_path("multi-turn.prompty", Some(&inputs)).await?;
+    ```
+  </TabItem>
 </Tabs>
 
-The `kind: thread` input is expanded into message objects at its position in the template — enabling stateless multi-turn conversations.
+The `kind: thread` inputis expanded into message objects at its position in the template — enabling stateless multi-turn conversations.
 
 ---
 
@@ -392,9 +438,14 @@ inputs:
     });
     ```
   </TabItem>
+  <TabItem label="Rust">
+    <Aside type="caution">
+      The Rust runtime does not yet support `apiType: embedding`. This feature is planned for a future release.
+    </Aside>
+  </TabItem>
 </Tabs>
 
-No role markers needed — the body is the raw text to embed.
+No role markers needed— the body is the raw text to embed.
 
 ---
 
@@ -461,9 +512,27 @@ user:
     var result = await Pipeline.TurnAsync(agent, inputs, tools: tools);
     ```
   </TabItem>
+  <TabItem label="Rust">
+    ```rust
+    use prompty::TurnOptions;
+
+    prompty::register_tool_handler("get_weather", |args| {
+        Box::pin(async move {
+            let city = args["city"].as_str().unwrap_or("unknown");
+            Ok(serde_json::json!(format!("72°F and sunny in {city}")))
+        })
+    });
+
+    let result = prompty::turn_from_path(
+        "weather-agent.prompty",
+        Some(&serde_json::json!({ "question": "Weather in Tokyo?" })),
+        Some(TurnOptions { max_iterations: Some(10), ..Default::default() }),
+    ).await?;
+    ```
+  </TabItem>
 </Tabs>
 
-The agent loop calls `get_weather`, appends the result, and re-queries the model for a natural language answer.
+The agent loop calls`get_weather`, appends the result, and re-queries the model for a natural language answer.
 
 ---
 
@@ -517,9 +586,15 @@ Topic: {{topic}}
     });
     ```
   </TabItem>
+  <TabItem label="Rust">
+    ```rust
+    let inputs = serde_json::json!({ "topic": "time travel paradox", "style": "poem" });
+    let result = prompty::invoke_from_path("creative-writer.prompty", Some(&inputs)).await?;
+    ```
+  </TabItem>
 </Tabs>
 
-Tuning `temperature` above 1.0 and `topP` near 1.0 gives the model more freedom for creative tasks.
+Tuning `temperature`above 1.0 and `topP` near 1.0 gives the model more freedom for creative tasks.
 
 ---
 
@@ -575,6 +650,16 @@ user:
     });
     ```
   </TabItem>
+  <TabItem label="Rust">
+    ```rust
+    let inputs = serde_json::json!({
+        "text": "Good morning!",
+        "sourceLang": "English",
+        "targetLang": "Japanese",
+    });
+    let result = prompty::invoke_from_path("translator.prompty", Some(&inputs)).await?;
+    ```
+  </TabItem>
 </Tabs>
 
-Low temperature (0.3) keeps translations faithful. Parameterizing the languages makes this a single reusable prompt for any language pair.
+Low temperature(0.3) keeps translations faithful. Parameterizing the languages makes this a single reusable prompt for any language pair.

--- a/web/src/content/docs/how-to/custom-providers.mdx
+++ b/web/src/content/docs/how-to/custom-providers.mdx
@@ -139,6 +139,42 @@ prepare() → messages → Executor.execute() → raw → Processor.process() �
     }
     ```
   </TabItem>
+  <TabItem label="Rust">
+    ```rust
+    // my_provider/executor.rs
+    use prompty::{Executor, InvokerError, Prompty, Message};
+    use async_trait::async_trait;
+    use serde_json::Value;
+
+    pub struct MyExecutor;
+
+    #[async_trait]
+    impl Executor for MyExecutor {
+        async fn execute(&self, agent: &Prompty, messages: &[Message]) -> Result<Value, InvokerError> {
+            let conn = &agent.model.connection;
+            let payload = serde_json::json!({
+                "model": agent.model.id,
+                "messages": messages.iter().map(|m| {
+                    serde_json::json!({"role": m.role, "content": m.text})
+                }).collect::<Vec<_>>(),
+            });
+
+            let client = reqwest::Client::new();
+            let resp = client
+                .post(format!("{}/v1/completions", conn.endpoint))
+                .bearer_auth(&conn.api_key)
+                .json(&payload)
+                .send()
+                .await
+                .map_err(|e| InvokerError::ExecutionError(e.to_string()))?;
+
+            let body: Value = resp.json().await
+                .map_err(|e| InvokerError::ExecutionError(e.to_string()))?;
+            Ok(body)
+        }
+    }
+    ```
+  </TabItem>
 </Tabs>
 
 ---
@@ -193,6 +229,23 @@ prepare() → messages → Executor.execute() → raw → Processor.process() �
                 .GetProperty("content")
                 .GetString();
             return Task.FromResult<object>(content!);
+        }
+    }
+    ```
+  </TabItem>
+  <TabItem label="Rust">
+    ```rust
+    // my_provider/processor.rs
+    use prompty::{Processor, InvokerError, Prompty};
+    use async_trait::async_trait;
+    use serde_json::Value;
+
+    pub struct MyProcessor;
+
+    #[async_trait]
+    impl Processor for MyProcessor {
+        async fn process(&self, _agent: &Prompty, response: Value) -> Result<Value, InvokerError> {
+            Ok(response["choices"][0]["message"]["content"].clone())
         }
     }
     ```
@@ -262,6 +315,19 @@ prepare() → messages → Executor.execute() → raw → Processor.process() �
         .AddMyProvider();
     ```
   </TabItem>
+  <TabItem label="Rust">
+    Register at application startup:
+
+    ```rust
+    use my_provider::{MyExecutor, MyProcessor};
+
+    fn main() {
+        prompty::register_defaults();
+        prompty::register_executor("my-custom", MyExecutor);
+        prompty::register_processor("my-custom", MyProcessor);
+    }
+    ```
+  </TabItem>
 </Tabs>
 
 ---
@@ -321,6 +387,25 @@ user:
     var inputs = new Dictionary<string, object?> { ["question"] = "Hello!" };
     var result = await Pipeline.InvokeAsync(agent, inputs);
     Console.WriteLine(result);
+    ```
+  </TabItem>
+  <TabItem label="Rust">
+    ```rust
+    use serde_json::json;
+
+    #[tokio::main]
+    async fn main() -> Result<(), Box<dyn std::error::Error>> {
+        prompty::register_defaults();
+        prompty::register_executor("my-custom", MyExecutor);
+        prompty::register_processor("my-custom", MyProcessor);
+
+        let result = prompty::invoke_from_path(
+            "custom-llm.prompty",
+            Some(&json!({ "question": "Hello!" })),
+        ).await?;
+        println!("{result}");
+        Ok(())
+    }
     ```
   </TabItem>
 </Tabs>

--- a/web/src/content/docs/how-to/embeddings.mdx
+++ b/web/src/content/docs/how-to/embeddings.mdx
@@ -98,6 +98,11 @@ inputs:
     Console.WriteLine(vector);
     ```
   </TabItem>
+  <TabItem label="Rust">
+    <Aside type="caution">
+      The Rust runtime does not yet support `apiType: embedding`. This feature is planned for a future release.
+    </Aside>
+  </TabItem>
 </Tabs>
 
 ---
@@ -176,6 +181,11 @@ inputs:
     // vectors is List<List<float>> — one vector per input text
     Console.WriteLine(vectors);
     ```
+  </TabItem>
+  <TabItem label="Rust">
+    <Aside type="caution">
+      The Rust runtime does not yet support `apiType: embedding`. This feature is planned for a future release.
+    </Aside>
   </TabItem>
 </Tabs>
 
@@ -293,6 +303,11 @@ A full, tested example you can copy and run:
   </TabItem>
   <TabItem label="C#">
     <Code code={csEmbeddings} lang="csharp" title="Embeddings.cs" />
+  </TabItem>
+  <TabItem label="Rust">
+    <Aside type="caution">
+      The Rust runtime does not yet support `apiType: embedding`. This feature is planned for a future release.
+    </Aside>
   </TabItem>
 </Tabs>
 

--- a/web/src/content/docs/how-to/foundry.mdx
+++ b/web/src/content/docs/how-to/foundry.mdx
@@ -39,6 +39,11 @@ import { Aside, Tabs, TabItem } from '@astrojs/starlight/components';
     dotnet add package Prompty.Foundry --prerelease
     ```
   </TabItem>
+  <TabItem label="Rust">
+    ```bash
+    cargo add prompty prompty-foundry
+    ```
+  </TabItem>
 </Tabs>
 
 <Aside type="tip" title="Migrating from Azure OpenAI?">
@@ -126,6 +131,24 @@ user:
     );
 
     Console.WriteLine(result);
+    ```
+  </TabItem>
+  <TabItem label="Rust">
+    ```rust
+    use serde_json::json;
+
+    #[tokio::main]
+    async fn main() -> Result<(), Box<dyn std::error::Error>> {
+        prompty::register_defaults();
+        prompty_foundry::register();
+
+        let result = prompty::invoke_from_path(
+            "foundry-chat.prompty",
+            Some(&json!({ "question": "What services does Microsoft Foundry offer?" })),
+        ).await?;
+        println!("{result}");
+        Ok(())
+    }
     ```
   </TabItem>
 </Tabs>
@@ -258,6 +281,33 @@ or VS Code login:
       credential registration is needed in C#.
     </Aside>
   </TabItem>
+  <TabItem label="Rust">
+    ```rust
+    use serde_json::json;
+
+    #[tokio::main]
+    async fn main() -> Result<(), Box<dyn std::error::Error>> {
+        prompty::register_defaults();
+        prompty_foundry::register();
+
+        // Register the named connection before loading the prompt
+        prompty::register_connection(
+            "foundry_default",
+            json!({
+                "endpoint": std::env::var("AZURE_AI_PROJECT_ENDPOINT")?,
+                "credential": "default",
+            }),
+        );
+
+        let result = prompty::invoke_from_path(
+            "foundry-chat-aad.prompty",
+            Some(&json!({ "question": "What is Microsoft Foundry?" })),
+        ).await?;
+        println!("{result}");
+        Ok(())
+    }
+    ```
+  </TabItem>
 </Tabs>
 
 ### 3. Production Deployment: Use Managed Identity
@@ -357,6 +407,33 @@ az role assignment create \
     );
 
     Console.WriteLine(result);
+    ```
+  </TabItem>
+  <TabItem label="Rust">
+    ```rust
+    use serde_json::json;
+
+    #[tokio::main]
+    async fn main() -> Result<(), Box<dyn std::error::Error>> {
+        prompty::register_defaults();
+        prompty_foundry::register();
+
+        // For production: use managed identity credential
+        prompty::register_connection(
+            "foundry_default",
+            json!({
+                "endpoint": std::env::var("AZURE_AI_PROJECT_ENDPOINT")?,
+                "credential": "managed_identity",
+            }),
+        );
+
+        let result = prompty::invoke_from_path(
+            "foundry-chat-aad.prompty",
+            Some(&json!({ "question": "What is Microsoft Foundry?" })),
+        ).await?;
+        println!("{result}");
+        Ok(())
+    }
     ```
   </TabItem>
 </Tabs>

--- a/web/src/content/docs/how-to/image-generation.mdx
+++ b/web/src/content/docs/how-to/image-generation.mdx
@@ -80,10 +80,15 @@ inputs:
     Console.WriteLine(url);
     ```
   </TabItem>
+  <TabItem label="Rust">
+    <Aside type="caution">
+      The Rust runtime does not yet support `apiType: image`. This feature is planned for a future release.
+    </Aside>
+  </TabItem>
 </Tabs>
 
 <Aside type="caution">
-  Image URLs are **temporary** (≈ 1 hour). Download anything you want to keep.
+  Image URLs are **temporary**(≈ 1 hour). Download anything you want to keep.
 </Aside>
 
 ---

--- a/web/src/content/docs/how-to/openai.mdx
+++ b/web/src/content/docs/how-to/openai.mdx
@@ -28,6 +28,11 @@ import { Aside, Tabs, TabItem } from '@astrojs/starlight/components';
     dotnet add package Prompty.OpenAI --prerelease
     ```
   </TabItem>
+  <TabItem label="Rust">
+    ```bash
+    cargo add prompty prompty-openai
+    ```
+  </TabItem>
 </Tabs>
 
 You also need an [OpenAI API key](https://platform.openai.com/api-keys).
@@ -150,6 +155,49 @@ user:
     // Step 3 — Call OpenAI + process response → string
     var result = await Pipeline.RunAsync(agent, messages);
     Console.WriteLine(result);
+    ```
+  </TabItem>
+  <TabItem label="Rust">
+    ```rust
+    use serde_json::json;
+
+    #[tokio::main]
+    async fn main() -> Result<(), Box<dyn std::error::Error>> {
+        prompty::register_defaults();
+        prompty_openai::register();
+
+        // One-liner: load → render → call LLM → return result
+        let result = prompty::invoke_from_path(
+            "chat.prompty",
+            Some(&json!({ "question": "What is Prompty?" })),
+        ).await?;
+        println!("{result}");
+        Ok(())
+    }
+    ```
+
+    For more control, use the pipeline stages individually:
+
+    ```rust
+    use serde_json::json;
+
+    #[tokio::main]
+    async fn main() -> Result<(), Box<dyn std::error::Error>> {
+        prompty::register_defaults();
+        prompty_openai::register();
+
+        // Step 1 — Load the .prompty file → Prompty
+        let agent = prompty::load("chat.prompty")?;
+
+        // Step 2 — Render template + parse role markers → Vec<Message>
+        let inputs = json!({ "question": "Explain async/await" });
+        let messages = prompty::prepare(&agent, Some(&inputs)).await?;
+
+        // Step 3 — Call OpenAI + process response → string
+        let result = prompty::run(&agent, &messages).await?;
+        println!("{result}");
+        Ok(())
+    }
     ```
   </TabItem>
 </Tabs>

--- a/web/src/content/docs/how-to/prompt-composition.mdx
+++ b/web/src/content/docs/how-to/prompt-composition.mdx
@@ -142,6 +142,35 @@ user:
     Console.WriteLine(result);
     ```
   </TabItem>
+  <TabItem label="Rust">
+    ```rust
+    // In Rust, PromptyTool is a registered tool kind.
+    // Define it in the .prompty frontmatter:
+    //   tools:
+    //     - name: summarize
+    //       kind: prompty
+    //       path: ./summarize.prompty
+    // The pipeline automatically loads and invokes the referenced .prompty file.
+
+    use serde_json::json;
+    use prompty::TurnOptions;
+
+    #[tokio::main]
+    async fn main() -> Result<(), Box<dyn std::error::Error>> {
+        prompty::register_defaults();
+        prompty_openai::register();
+
+        let agent = prompty::load("orchestrator.prompty")?;
+        let result = prompty::turn_from_path(
+            "orchestrator.prompty",
+            Some(&json!({ "article": "OpenAI announced GPT-5 today..." })),
+            Some(TurnOptions::default()),
+        ).await?;
+        println!("{result}");
+        Ok(())
+    }
+    ```
+  </TabItem>
 </Tabs>
 
 No tool functions to register — the runtime resolves `kind: prompty` tools automatically

--- a/web/src/content/docs/how-to/streaming.mdx
+++ b/web/src/content/docs/how-to/streaming.mdx
@@ -160,9 +160,36 @@ pass it to `process()` which yields text chunks.
     Console.WriteLine();
     ```
   </TabItem>
+  <TabItem label="Rust">
+    ```rust
+    use prompty::{StreamChunk, consume_stream_chunks};
+    use serde_json::json;
+
+    #[tokio::main]
+    async fn main() -> Result<(), Box<dyn std::error::Error>> {
+        prompty::register_defaults();
+        prompty_openai::register();
+
+        let agent = prompty::load("chat.prompty")?;
+        let inputs = json!({ "question": "Tell me a joke" });
+        let messages = prompty::prepare(&agent, Some(&inputs)).await?;
+        let result = prompty::run(&agent, &messages).await?;
+
+        let stream = prompty::from_structured_value::<prompty::PromptyStream>(&result)?;
+        consume_stream_chunks(stream, |chunk| match chunk {
+            StreamChunk::Text(t) => print!("{t}"),
+            StreamChunk::Thinking(t) => { /* reasoning tokens */ },
+            StreamChunk::Tool(tc) => { /* tool call */ },
+            StreamChunk::Error(e) => eprintln!("{e}"),
+        }).await;
+        println!();
+        Ok(())
+    }
+    ```
+  </TabItem>
 </Tabs>
 
-Each `chunk` is a **string** — the processor extracts `delta.content` from
+Each `chunk` is a **string**— the processor extracts `delta.content` from
 the raw API response objects so you don't handle the wire format yourself.
 
 ---
@@ -274,6 +301,33 @@ A full, tested example you can copy and run:
   </TabItem>
   <TabItem label="C#">
     <Code code={csStreaming} lang="csharp" title="Streaming.cs" />
+  </TabItem>
+  <TabItem label="Rust">
+    ```rust
+    use prompty::{StreamChunk, consume_stream_chunks};
+    use serde_json::json;
+
+    #[tokio::main]
+    async fn main() -> Result<(), Box<dyn std::error::Error>> {
+        prompty::register_defaults();
+        prompty_openai::register();
+
+        let agent = prompty::load("chat.prompty")?;
+        let inputs = json!({ "question": "Tell me a short joke" });
+        let messages = prompty::prepare(&agent, Some(&inputs)).await?;
+        let result = prompty::run(&agent, &messages).await?;
+
+        let stream = prompty::from_structured_value::<prompty::PromptyStream>(&result)?;
+        consume_stream_chunks(stream, |chunk| match chunk {
+            StreamChunk::Text(t) => print!("{t}"),
+            StreamChunk::Thinking(_) => {},
+            StreamChunk::Tool(_) => {},
+            StreamChunk::Error(e) => eprintln!("{e}"),
+        }).await;
+        println!();
+        Ok(())
+    }
+    ```
   </TabItem>
 </Tabs>
 

--- a/web/src/content/docs/how-to/structured-output.mdx
+++ b/web/src/content/docs/how-to/structured-output.mdx
@@ -122,10 +122,32 @@ valid JSON with exactly those fields.
     }
     ```
   </TabItem>
+  <TabItem label="Rust">
+    ```rust
+    use serde_json::json;
+
+    #[tokio::main]
+    async fn main() -> Result<(), Box<dyn std::error::Error>> {
+        prompty::register_defaults();
+        prompty_openai::register();
+
+        let result = prompty::invoke_from_path(
+            "weather.prompty",
+            Some(&json!({ "city": "Seattle" })),
+        ).await?;
+
+        // result is a parsed serde_json::Value matching the outputSchema
+        println!("{}", result["city"]);         // "Seattle"
+        println!("{}", result["temperature"]);  // 62
+        println!("{}", result["conditions"]);   // "Partly cloudy"
+        Ok(())
+    }
+    ```
+  </TabItem>
 </Tabs>
 
 <Aside type="tip">
-  Without `outputs`, `invoke()` returns a raw string. With it, you get
+  Without `outputs`, `invoke()` returns a raw string.With it, you get
   a `StructuredResult` — a dict (Python) / object (TypeScript) / Dictionary (C#)
   that also carries the raw JSON for efficient casting.
 </Aside>
@@ -216,6 +238,21 @@ Weather for {{city}}?
     }
     ```
   </TabItem>
+  <TabItem label="Rust">
+    ```rust
+    use serde_json::json;
+
+    let result = prompty::invoke_from_path(
+        "detailed-weather.prompty",
+        Some(&json!({ "city": "Portland" })),
+    ).await?;
+
+    println!("{}", result["city"]);                     // "Portland"
+    println!("{}", result["current"]["temperature"]);   // 58
+    println!("{}", result["current"]["humidity"]);      // 72
+    println!("{}", result["forecast"]);                 // [{"day": "Mon", ...}, ...]
+    ```
+  </TabItem>
 </Tabs>
 
 <Aside type="caution">
@@ -304,6 +341,29 @@ deserializes directly from the raw JSON — no dict→JSON→T round-trip.
         new() { ["city"] = "Seattle" });
     ```
   </TabItem>
+  <TabItem label="Rust">
+    ```rust
+    use serde::Deserialize;
+    use serde_json::json;
+
+    #[derive(Deserialize, Debug)]
+    struct WeatherReport {
+        city: String,
+        temperature: i32,
+        conditions: String,
+    }
+
+    let result = prompty::invoke_from_path(
+        "weather.prompty",
+        Some(&json!({ "city": "Seattle" })),
+    ).await?;
+
+    // Deserialize the structured JSON into a typed struct
+    let report: WeatherReport = serde_json::from_value(result)?;
+    println!("{}", report.city);   // "Seattle"
+    println!("{:?}", report);      // WeatherReport { city: "Seattle", ... }
+    ```
+  </TabItem>
 </Tabs>
 
 ---
@@ -356,6 +416,34 @@ A full, tested example you can copy and run:
   </TabItem>
   <TabItem label="C#">
     <Code code={csStructured} lang="csharp" title="StructuredOutput.cs" />
+  </TabItem>
+  <TabItem label="Rust">
+    ```rust
+    use serde::Deserialize;
+    use serde_json::json;
+
+    #[derive(Deserialize, Debug)]
+    struct WeatherReport {
+        city: String,
+        temperature: i32,
+        conditions: String,
+    }
+
+    #[tokio::main]
+    async fn main() -> Result<(), Box<dyn std::error::Error>> {
+        prompty::register_defaults();
+        prompty_openai::register();
+
+        let result = prompty::invoke_from_path(
+            "weather.prompty",
+            Some(&json!({ "city": "Seattle" })),
+        ).await?;
+
+        let report: WeatherReport = serde_json::from_value(result)?;
+        println!("{report:?}");
+        Ok(())
+    }
+    ```
   </TabItem>
 </Tabs>
 

--- a/web/src/content/docs/how-to/testing-prompts.mdx
+++ b/web/src/content/docs/how-to/testing-prompts.mdx
@@ -74,6 +74,24 @@ Load a `.prompty` file and assert its properties. No LLM call is made.
     }
     ```
   </TabItem>
+  <TabItem label="Rust">
+    ```rust
+    #[cfg(test)]
+    mod tests {
+        use serde_json::json;
+
+        #[test]
+        fn test_load_prompt() {
+            prompty::register_defaults();
+            let agent = prompty::load("prompts/chat.prompty").unwrap();
+
+            assert_eq!(agent.name, "openai-chat");
+            assert_eq!(agent.model.id, "gpt-4o-mini");
+            assert_eq!(agent.model.provider, "openai");
+        }
+    }
+    ```
+  </TabItem>
 </Tabs>
 
 ---
@@ -133,6 +151,26 @@ calling the LLM**. Assert on message count, roles, and interpolated content.
             Assert.True(messages.Count >= 2);
             Assert.Equal("system", messages[0].Role);
             Assert.Contains("What is Prompty?", messages[^1].Text);
+        }
+    }
+    ```
+  </TabItem>
+  <TabItem label="Rust">
+    ```rust
+    #[cfg(test)]
+    mod tests {
+        use serde_json::json;
+
+        #[tokio::test]
+        async fn test_prepare_messages() {
+            prompty::register_defaults();
+            let agent = prompty::load("prompts/chat.prompty").unwrap();
+            let inputs = json!({ "question": "What is Prompty?" });
+            let messages = prompty::prepare(&agent, Some(&inputs)).await.unwrap();
+
+            assert!(messages.len() >= 2);
+            assert_eq!(messages[0].role, prompty::Role::System);
+            assert_eq!(messages.last().unwrap().role, prompty::Role::User);
         }
     }
     ```
@@ -247,6 +285,50 @@ mocking the LLM SDK client so no real API call is made.
     }
     ```
   </TabItem>
+  <TabItem label="Rust">
+    ```rust
+    #[cfg(test)]
+    mod tests {
+        use serde_json::json;
+
+        // Register a mock executor that returns a canned response
+        struct MockExecutor;
+
+        #[async_trait::async_trait]
+        impl prompty::Executor for MockExecutor {
+            async fn execute(
+                &self, _agent: &prompty::Prompty, _messages: &[prompty::Message],
+            ) -> Result<serde_json::Value, prompty::InvokerError> {
+                Ok(json!({"choices": [{"message": {"content": "Mocked answer"}}]}))
+            }
+        }
+
+        struct MockProcessor;
+
+        #[async_trait::async_trait]
+        impl prompty::Processor for MockProcessor {
+            async fn process(
+                &self, _agent: &prompty::Prompty, response: serde_json::Value,
+            ) -> Result<serde_json::Value, prompty::InvokerError> {
+                Ok(response["choices"][0]["message"]["content"].clone())
+            }
+        }
+
+        #[tokio::test]
+        async fn test_invoke_with_mock() {
+            prompty::register_defaults();
+            prompty::register_executor("openai", MockExecutor);
+            prompty::register_processor("openai", MockProcessor);
+
+            let result = prompty::invoke_from_path(
+                "prompts/chat.prompty",
+                Some(&json!({ "question": "test" })),
+            ).await.unwrap();
+            assert_eq!(result.as_str().unwrap(), "Mocked answer");
+        }
+    }
+    ```
+  </TabItem>
 </Tabs>
 
 ---
@@ -330,5 +412,34 @@ to live tests locally.
     <Aside type="note">
       [`Xunit.SkippableFact`](https://www.nuget.org/packages/Xunit.SkippableFact) provides `Skip.IfNot()`.
     </Aside>
+  </TabItem>
+  <TabItem label="Rust">
+    ```rust
+    #[cfg(test)]
+    mod integration_tests {
+        use serde_json::json;
+
+        fn has_openai_key() -> bool {
+            std::env::var("OPENAI_API_KEY").is_ok()
+        }
+
+        #[tokio::test]
+        async fn test_live_chat() {
+            if !has_openai_key() {
+                eprintln!("Skipping: OPENAI_API_KEY not set");
+                return;
+            }
+
+            prompty::register_defaults();
+            prompty_openai::register();
+
+            let result = prompty::invoke_from_path(
+                "prompts/chat.prompty",
+                Some(&json!({ "question": "Say hello in one word." })),
+            ).await.unwrap();
+            assert!(result.as_str().map_or(false, |s| !s.is_empty()));
+        }
+    }
+    ```
   </TabItem>
 </Tabs>

--- a/web/src/content/docs/how-to/troubleshooting.mdx
+++ b/web/src/content/docs/how-to/troubleshooting.mdx
@@ -63,6 +63,12 @@ console.log(resolve("chat.prompty"));  // see what Prompty will look for
 Console.WriteLine(Path.GetFullPath("chat.prompty"));  // see what Prompty will look for
 ```
 </TabItem>
+  <TabItem label="Rust">
+    ```rust
+    use std::path::Path;
+    println!("{}", Path::new("chat.prompty").canonicalize()?.display());
+    ```
+  </TabItem>
 </Tabs>
 
 ### Missing Environment Variable
@@ -145,6 +151,18 @@ exists at that relative location.
 
     new PromptyBuilder()
         .AddOpenAI();
+    ```
+  </TabItem>
+  <TabItem label="Rust">
+    ```
+    Error: "No executor registered for key 'openai'"
+    ```
+
+    **Fix:** Call the provider registration function before invoking:
+
+    ```rust
+    prompty::register_defaults();
+    prompty_openai::register(); // registers the OpenAI executor + processor
     ```
   </TabItem>
 </Tabs>
@@ -249,6 +267,16 @@ using Prompty.Core;
 static string GetWeather(string city) => $"72°F in {city}";
 ```
 </TabItem>
+  <TabItem label="Rust">
+    ```rust
+    prompty::register_tool_handler("get_weather", |args| {
+        Box::pin(async move {
+            let city = args["city"].as_str().unwrap_or("unknown");
+            Ok(serde_json::json!(format!("72°F in {city}")))
+        })
+    });
+    ```
+  </TabItem>
 </Tabs>
 
 ### Tool Schema Mismatch
@@ -308,6 +336,22 @@ await foreach (var chunk in result)
 }
 ```
 </TabItem>
+  <TabItem label="Rust">
+    ```rust
+    use prompty::{StreamChunk, consume_stream_chunks};
+
+    let agent = prompty::load("chat.prompty")?;
+    let inputs = serde_json::json!({ "question": "Hello" });
+    let messages = prompty::prepare(&agent, Some(&inputs)).await?;
+    let result = prompty::run(&agent, &messages).await?;
+
+    let stream = prompty::from_structured_value::<prompty::PromptyStream>(&result)?;
+    consume_stream_chunks(stream, |chunk| match chunk {
+        StreamChunk::Text(t) => print!("{t}"),
+        _ => {},
+    }).await;
+    ```
+  </TabItem>
 </Tabs>
 
 ### Model Refused Response
@@ -379,6 +423,20 @@ Tracer.Add("console", name => new ConsoleTracer(name));
 var result = await Pipeline.InvokeAsync("chat.prompty", new() { ["question"] = "Hello" });
 ```
 </TabItem>
+  <TabItem label="Rust">
+    ```rust
+    prompty::register_defaults();
+    prompty_openai::register();
+
+    // Enable console tracing — see exactly what goes to/from the LLM
+    prompty::tracing::enable_console_tracing();
+
+    let result = prompty::invoke_from_path(
+        "chat.prompty",
+        Some(&serde_json::json!({ "question": "Hello" })),
+    ).await?;
+    ```
+  </TabItem>
 </Tabs>
 
 ### Use `prepare()` to Inspect Messages
@@ -419,6 +477,16 @@ foreach (var msg in messages)
 }
 ```
 </TabItem>
+  <TabItem label="Rust">
+    ```rust
+    let agent = prompty::load("chat.prompty")?;
+    let inputs = serde_json::json!({ "name": "Jane" });
+    let messages = prompty::prepare(&agent, Some(&inputs)).await?;
+    for msg in &messages {
+        println!("[{}] {}", msg.role, msg.content);
+    }
+    ```
+  </TabItem>
 </Tabs>
 
 ### Verify With a Minimal Example

--- a/web/src/content/docs/implementation/index.mdx
+++ b/web/src/content/docs/implementation/index.mdx
@@ -14,6 +14,7 @@ same pipeline architecture but uses language-native patterns and package manager
 | [**Python**](/implementation/python/) | ✅ Stable (alpha) | `prompty` on PyPI |
 | [**TypeScript**](/implementation/typescript/) | ✅ Stable (alpha) | `@prompty/core` on npm |
 | [**C#**](/implementation/csharp/) | ✅ Alpha | `Prompty.Core`, `Prompty.OpenAI`, `Prompty.Foundry`, `Prompty.Anthropic` on NuGet |
+| [**Rust**](/implementation/rust/) | ✅ Alpha | `prompty`, `prompty-openai`, `prompty-foundry`, `prompty-anthropic` on crates.io |
 
 ## Choosing a Runtime
 
@@ -41,3 +42,11 @@ and available providers.
 - Static `Pipeline` API with async-first design
 - Same four-stage render → parse → execute → process architecture
 - Install: `dotnet add package Prompty.Core --prerelease`
+
+### Rust
+
+- Async-only runtime (Tokio) with zero-cost abstractions
+- Modular crate architecture (`prompty` core + provider crates)
+- Trait-based plugin system (`Executor`, `Processor`, `Renderer`, `Parser`)
+- Full agent loop with events, cancellation, guardrails, and steering
+- Install: `cargo add prompty prompty-openai`

--- a/web/src/content/docs/implementation/rust.mdx
+++ b/web/src/content/docs/implementation/rust.mdx
@@ -1,0 +1,278 @@
+---
+title: Rust
+description: >
+  Using Prompty with Rust — installation, crate structure, API overview, and async patterns.
+sidebar:
+  order: 4
+---
+
+import { Aside, Tabs, TabItem } from '@astrojs/starlight/components';
+
+## Installation
+
+Prompty for Rust requires **Rust ≥ 1.85** (edition 2024) and an async runtime ([Tokio](https://tokio.rs/)).
+
+```bash
+# Core runtime
+cargo add prompty
+
+# Add a provider (pick one or more)
+cargo add prompty-openai      # OpenAI
+cargo add prompty-foundry     # Azure OpenAI / Foundry
+cargo add prompty-anthropic   # Anthropic Claude
+```
+
+### Crate Structure
+
+| Crate | Description | crates.io |
+|-------|------------|-----------|
+| [`prompty`](https://crates.io/crates/prompty) | Core pipeline, types, registry, tracing | [![crates.io](https://img.shields.io/crates/v/prompty.svg)](https://crates.io/crates/prompty) |
+| [`prompty-openai`](https://crates.io/crates/prompty-openai) | OpenAI executor & processor | [![crates.io](https://img.shields.io/crates/v/prompty-openai.svg)](https://crates.io/crates/prompty-openai) |
+| [`prompty-foundry`](https://crates.io/crates/prompty-foundry) | Azure OpenAI / Foundry executor & processor | [![crates.io](https://img.shields.io/crates/v/prompty-foundry.svg)](https://crates.io/crates/prompty-foundry) |
+| [`prompty-anthropic`](https://crates.io/crates/prompty-anthropic) | Anthropic Claude executor & processor | [![crates.io](https://img.shields.io/crates/v/prompty-anthropic.svg)](https://crates.io/crates/prompty-anthropic) |
+
+### Feature Flags
+
+The core `prompty` crate has optional features:
+
+| Feature | What it enables |
+|---------|----------------|
+| `otel` | OpenTelemetry tracing backend (`opentelemetry`, `opentelemetry_sdk`, `opentelemetry-stdout`) |
+
+The `prompty-foundry` crate has:
+
+| Feature | What it enables |
+|---------|----------------|
+| `entra_id` | Azure Entra ID (AAD) authentication via `azure_identity` |
+
+```bash
+# Enable OpenTelemetry tracing
+cargo add prompty --features otel
+
+# Enable Entra ID authentication for Foundry
+cargo add prompty-foundry --features entra_id
+```
+
+## Quick Start
+
+```rust
+use prompty;
+use prompty_openai;
+use serde_json::json;
+
+#[tokio::main]
+async fn main() -> Result<(), Box<dyn std::error::Error>> {
+    // 1. Register providers (once at startup)
+    prompty::register_defaults();
+    prompty_openai::register();
+
+    // 2. Load and invoke
+    let result = prompty::invoke_from_path(
+        "greeting.prompty",
+        Some(&json!({ "userName": "Jane" })),
+    ).await?;
+
+    println!("{result}");
+    Ok(())
+}
+```
+
+<Aside type="note">
+  `register_defaults()` registers built-in renderers (Nunjucks, Mustache) and the
+  Prompty chat parser. Provider crates like `prompty_openai::register()` register
+  their executor and processor under the `"openai"` key.
+</Aside>
+
+## API Overview
+
+### Loading
+
+```rust
+// Load a .prompty file into a typed Prompty object
+let agent = prompty::load("chat.prompty")?;
+
+println!("{}", agent.name);                    // "chat"
+println!("{}", agent.model.id);                // "gpt-4o"
+println!("{:?}", agent.instructions);          // Some("the markdown body")
+
+// Async loading (non-blocking file I/O)
+let agent = prompty::load_async("chat.prompty").await?;
+
+// Load from a string (no file needed)
+let agent = prompty::load_from_string(raw_content, ".")?;
+```
+
+### Pipeline Functions
+
+```rust
+use serde_json::json;
+
+let agent = prompty::load("chat.prompty")?;
+let inputs = json!({ "q": "Hi" });
+
+// Render template + parse role markers → Vec<Message>
+let messages = prompty::prepare(&agent, Some(&inputs)).await?;
+
+// Execute LLM + process response → serde_json::Value
+let result = prompty::run(&agent, &messages).await?;
+
+// One-shot: prepare + run
+let result = prompty::invoke_agent(&agent, Some(&inputs)).await?;
+
+// Load from path + invoke in one call
+let result = prompty::invoke_from_path("chat.prompty", Some(&inputs)).await?;
+```
+
+### Async-Only Design
+
+Rust's Prompty runtime is **async-only** — all pipeline functions are `async fn`
+and require a Tokio runtime. This is idiomatic for Rust I/O and network operations.
+
+```rust
+#[tokio::main]
+async fn main() {
+    let result = prompty::invoke_from_path("chat.prompty", None).await.unwrap();
+}
+```
+
+<Aside type="tip">
+  Unlike Python (which has sync + async variants) and TypeScript (which is natively async),
+  Rust uses explicit async runtimes. All Prompty functions return futures that must be `.await`ed.
+</Aside>
+
+### Agent Mode (turn)
+
+The `turn()` function runs an agent loop — the LLM can call tools, and the runtime
+executes them automatically until it produces a final response.
+
+```rust
+use prompty::{TurnOptions, Steering, AgentEvent};
+use serde_json::json;
+use std::sync::Arc;
+
+// Register tool handlers
+prompty::register_tool_handler("get_weather", |args| {
+    Box::pin(async move {
+        let city = args["city"].as_str().unwrap_or("unknown");
+        Ok(json!(format!("72°F and sunny in {city}")))
+    })
+});
+
+let agent = prompty::load("agent.prompty")?;
+
+let options = TurnOptions {
+    max_iterations: Some(10),
+    events: Some(Arc::new(|event: AgentEvent| {
+        println!("Event: {event:?}");
+    })),
+    ..Default::default()
+};
+
+let result = prompty::turn(
+    &agent,
+    Some(&json!({ "question": "What's the weather in Seattle?" })),
+    Some(options),
+).await?;
+```
+
+### Connection Registry
+
+Pre-register named connections for production use:
+
+```rust
+use serde_json::json;
+
+// Register a named connection
+prompty::register_connection("my-openai", json!({
+    "kind": "key",
+    "apiKey": std::env::var("OPENAI_API_KEY").unwrap(),
+}));
+
+// .prompty files can reference it:
+// connection:
+//   kind: reference
+//   name: my-openai
+```
+
+### Tracing
+
+```rust
+use prompty::{Tracer, PromptyTracer, console_tracer, trace_async};
+
+// Register a file-based tracer (writes .tracy JSON files)
+let pt = PromptyTracer::new("./traces");
+Tracer::register("json", pt.tracer());
+
+// Register the console tracer
+Tracer::register("console", console_tracer);
+
+// Trace custom async functions
+let result = trace_async("my_pipeline", json!({"query": q}), async {
+    prompty::invoke_from_path("search.prompty", Some(&inputs)).await
+}).await?;
+```
+
+## Providers
+
+| Provider | Crate | Registration Key | Auth |
+|----------|-------|-----------------|------|
+| OpenAI | `prompty-openai` | `openai` | API key |
+| Azure OpenAI / Foundry | `prompty-foundry` | `foundry` | API key or Entra ID |
+| Anthropic | `prompty-anthropic` | `anthropic` | API key |
+
+Register providers at startup — once registered, any `.prompty` file with a matching
+`provider` value will use that executor and processor:
+
+```rust
+prompty::register_defaults();  // renderers + parser
+prompty_openai::register();    // "openai" executor + processor
+prompty_foundry::register();   // "foundry" executor + processor
+prompty_anthropic::register(); // "anthropic" executor + processor
+```
+
+## Environment Variables
+
+Prompty resolves `${env:VAR}` references in `.prompty` frontmatter from the process
+environment. Set them before loading:
+
+```bash
+export OPENAI_API_KEY=sk-your-key-here
+export AZURE_OPENAI_ENDPOINT=https://myresource.openai.azure.com/
+export AZURE_OPENAI_API_KEY=abc123
+export ANTHROPIC_API_KEY=sk-ant-your-key-here
+```
+
+<Aside type="caution">
+  Unlike Python, the Rust runtime does **not** auto-load `.env` files. Use a crate
+  like [`dotenvy`](https://crates.io/crates/dotenvy) if you want `.env` support:
+  ```rust
+  dotenvy::dotenv().ok();
+  ```
+</Aside>
+
+## Current Limitations
+
+The Rust runtime covers the core Prompty pipeline comprehensively but has some gaps
+compared to the Python and TypeScript runtimes:
+
+| Feature | Status | Notes |
+|---------|--------|-------|
+| Chat completions | ✅ | All providers |
+| Streaming | ✅ | `PromptyStream` with tracing |
+| Agent loop / `turn()` | ✅ | Events, cancellation, guardrails, steering |
+| Structured output | ✅ | `outputSchema` → `response_format` |
+| Tracing | ✅ | `.tracy`, console, OpenTelemetry |
+| Custom providers | ✅ | Implement `Executor` + `Processor` traits |
+| Embeddings API | ❌ | `apiType: embedding` not yet supported |
+| Images API | ❌ | `apiType: image` not yet supported |
+| Responses API | ❌ | OpenAI Responses API not yet supported |
+| MCP tools | ❌ | MCP tool kind not yet supported |
+| OpenAPI tools | ❌ | OpenAPI tool kind not yet supported |
+
+These features are planned for future releases. Contributions welcome!
+
+## Further Reading
+
+- [API Reference](/api-reference/) — complete type reference
+- [How-To Guides](/how-to/openai/) — practical recipes
+- [Core Concepts](/core-concepts/) — architecture deep-dives

--- a/web/src/content/docs/migration.mdx
+++ b/web/src/content/docs/migration.mdx
@@ -44,6 +44,7 @@ you need:
 | **Python** | `uv pip install prompty[jinja2,openai]` |
 | **TypeScript** | `npm install @prompty/core @prompty/openai` |
 | **C#** | `dotnet add package Prompty.OpenAI` |
+| **Rust** | `cargo add prompty prompty-openai` |
 
 **Python extras:**
 
@@ -105,6 +106,28 @@ var result = await Pipeline.TurnAsync(
     tools: tools);
 ```
 </TabItem>
+<TabItem label="Rust">
+```rust
+// Rust is new in v2 — no v1 equivalent
+
+// v2 — tools passed explicitly
+use prompty;
+use serde_json::json;
+
+prompty::register_tool_handler("get_weather", |args| {
+    Box::pin(async move {
+        let city = args["city"].as_str().unwrap_or("unknown");
+        Ok(json!(format!("72°F in {city}")))
+    })
+});
+
+let result = prompty::turn_from_path(
+    "agent.prompty",
+    Some(&json!({ "question": "What's the weather?" })),
+    None,
+).await?;
+```
+</TabItem>
 </Tabs>
 
 ### Azure Credentials
@@ -162,6 +185,21 @@ ConnectionRegistry.Register("azure", new AzureOpenAIConnectionOptions
 {
     Endpoint = Environment.GetEnvironmentVariable("AZURE_ENDPOINT")!,
     Credential = credential,
+});
+```
+</TabItem>
+<TabItem label="Rust">
+```rust
+// v2 — explicit credential setup
+use prompty;
+use prompty_openai;
+
+let credential = azure_identity::DefaultAzureCredential::new()?;
+let endpoint = std::env::var("AZURE_ENDPOINT")?;
+
+prompty::register_connection("azure", prompty_openai::AzureConnectionOptions {
+    endpoint,
+    credential: Box::new(credential),
 });
 ```
 </TabItem>
@@ -281,5 +319,5 @@ template:
 - **Structured output** — `outputs` → `response_format` for type-safe JSON responses
 - **Thread safety** — renderer nonces use thread-local storage
 - **Entry-point discovery** (Python) — third-party providers register as plugins
-- **Multi-runtime support** — Python (`prompty`), TypeScript (`@prompty/core`), and C# (`Prompty.Core`) all share the same `.prompty` file format
+- **Multi-runtime support** — Python (`prompty`), TypeScript (`@prompty/core`), C# (`Prompty.Core`), and Rust (`prompty`) all share the same `.prompty` file format
 - **C# runtime** — `Prompty.Core`, `Prompty.OpenAI`, `Prompty.Foundry`, `Prompty.Anthropic` NuGet packages

--- a/web/src/content/docs/tutorials/chat-assistant.mdx
+++ b/web/src/content/docs/tutorials/chat-assistant.mdx
@@ -40,9 +40,14 @@ load → prepare → execute → process pipeline, and how thread inputs work.
     dotnet add package Prompty.OpenAI --prerelease
     ```
   </TabItem>
+  <TabItem label="Rust">
+    ```bash
+    cargo add prompty prompty-openai tokio serde_json
+    ```
+  </TabItem>
 </Tabs>
 
-Create a **`.env`** file in your project root with your OpenAI key:
+Create a **`.env`** filein your project root with your OpenAI key:
 
 ```bash
 OPENAI_API_KEY=sk-your-key-here
@@ -140,6 +145,27 @@ The quickest way — one function call that handles everything:
     // → "Prompty is a markdown file format for LLM prompts..."
     ```
   </TabItem>
+  <TabItem label="Rust">
+    ```rust
+    use prompty;
+    use prompty_openai;
+    use serde_json::json;
+
+    #[tokio::main]
+    async fn main() -> Result<(), Box<dyn std::error::Error>> {
+        prompty::register_defaults();
+        prompty_openai::register();
+
+        let result = prompty::invoke_from_path(
+            "assistant.prompty",
+            Some(&json!({ "question": "What is Prompty?" })),
+        ).await?;
+        println!("{result}");
+        // → "Prompty is a markdown file format for LLM prompts..."
+        Ok(())
+    }
+    ```
+  </TabItem>
 </Tabs>
 
 `invoke()` handles the full pipeline: **load** the file → **render** the
@@ -206,9 +232,37 @@ For more control, break the pipeline into individual steps:
     Console.WriteLine(result);
     ```
   </TabItem>
+  <TabItem label="Rust">
+    ```rust
+    use prompty;
+    use prompty_openai;
+    use serde_json::json;
+
+    #[tokio::main]
+    async fn main() -> Result<(), Box<dyn std::error::Error>> {
+        prompty::register_defaults();
+        prompty_openai::register();
+
+        // 1. Load — parse the .prompty file into a typed Prompty
+        let agent = prompty::load("assistant.prompty")?;
+
+        // 2. Prepare — render the template + parse role markers → messages
+        let messages = prompty::prepare(
+            &agent,
+            Some(&json!({ "question": "Explain async/await" })),
+        ).await?;
+        println!("{messages:?}");
+
+        // 3. Run — call the LLM + process the response → clean string
+        let result = prompty::run(&agent, &messages).await?;
+        println!("{result}");
+        Ok(())
+    }
+    ```
+  </TabItem>
 </Tabs>
 
-This is useful when you need to inspect or modify the messages before sending
+This is useful when you need to inspector modify the messages before sending
 them to the LLM — for example, injecting extra context from a database.
 
 ---
@@ -332,9 +386,49 @@ Now accumulate messages across turns:
     }
     ```
   </TabItem>
+  <TabItem label="Rust">
+    ```rust
+    use prompty;
+    use prompty_openai;
+    use serde_json::json;
+    use std::io::{self, Write};
+
+    #[tokio::main]
+    async fn main() -> Result<(), Box<dyn std::error::Error>> {
+        prompty::register_defaults();
+        prompty_openai::register();
+
+        let mut history: Vec<serde_json::Value> = vec![];
+
+        loop {
+            print!("You: ");
+            io::stdout().flush()?;
+            let mut question = String::new();
+            io::stdin().read_line(&mut question)?;
+            let question = question.trim();
+            if question == "quit" || question == "exit" {
+                break;
+            }
+
+            let result = prompty::invoke_from_path(
+                "assistant.prompty",
+                Some(&json!({
+                    "question": question,
+                    "conversation": history,
+                })),
+            ).await?;
+            println!("Assistant: {result}\n");
+
+            history.push(json!({"role": "user", "content": question}));
+            history.push(json!({"role": "assistant", "content": result}));
+        }
+        Ok(())
+    }
+    ```
+  </TabItem>
 </Tabs>
 
-Each call now includes the full conversation history. The pipeline injects
+Each call now includes the full conversation history.The pipeline injects
 the `conversation` thread messages between the system prompt and the new
 user message, so the LLM sees the entire context.
 
@@ -374,9 +468,18 @@ at the top of your script:
     // Now every InvokeAsync() call prints trace details to stdout
     ```
   </TabItem>
+  <TabItem label="Rust">
+    ```rust
+    use prompty::{Tracer, console_tracer};
+
+    Tracer::register("console", console_tracer);
+
+    // Now every invoke_from_path() call prints trace details to stdout
+    ```
+  </TabItem>
 </Tabs>
 
-The console tracer logs each pipeline stage — you'll see the rendered prompt,
+The console tracer logs each pipeline stage— you'll see the rendered prompt,
 the parsed messages, the raw LLM response, and the processed result. It's
 invaluable for debugging unexpected outputs.
 

--- a/web/src/content/docs/tutorials/production.mdx
+++ b/web/src/content/docs/tutorials/production.mdx
@@ -134,6 +134,21 @@ Register the client at application startup:
     ConnectionRegistry.Register("prod-client", client);
     ```
   </TabItem>
+  <TabItem label="Rust">
+    ```rust
+    use prompty;
+    use serde_json::json;
+
+    prompty::register_connection("prod-client", json!({
+        "kind": "key",
+        "endpoint": std::env::var("AZURE_ENDPOINT")?,
+        "apiKey": std::env::var("AZURE_API_KEY")?,
+    }));
+
+    // For managed identity, configure via environment variables
+    // and use the Azure SDK's DefaultAzureCredential equivalent.
+    ```
+  </TabItem>
 </Tabs>
 
 <Aside type="note">
@@ -169,6 +184,13 @@ Register the client at application startup:
     using Prompty.Core.Tracing;
 
     Tracer.Add("console", ConsoleTracer.Factory);
+    ```
+  </TabItem>
+  <TabItem label="Rust">
+    ```rust
+    use prompty::{Tracer, console_tracer};
+
+    Tracer::register("console", console_tracer);
     ```
   </TabItem>
 </Tabs>
@@ -208,6 +230,23 @@ Register the client at application startup:
     using Prompty.Core.Tracing;
 
     OTelTracer.Register();
+    ```
+  </TabItem>
+  <TabItem label="Rust">
+    ```rust
+    use prompty::Tracer;
+
+    // Sends spans to your OTel collector (Jaeger, Azure Monitor, etc.)
+    #[cfg(feature = "otel")]
+    {
+        prompty::init_otel_stdout();
+        Tracer::register("otel", prompty::otel_tracer());
+    }
+    ```
+
+    Enable the feature in `Cargo.toml`:
+    ```toml
+    prompty = { version = "...", features = ["otel"] }
     ```
   </TabItem>
 </Tabs>
@@ -301,6 +340,37 @@ timeouts, and authentication errors.
     }
     ```
   </TabItem>
+  <TabItem label="Rust">
+    ```rust
+    use prompty;
+    use serde_json::json;
+
+    async fn safe_invoke(
+        path: &str,
+        inputs: &serde_json::Value,
+    ) -> Option<String> {
+        match prompty::invoke_from_path(path, Some(inputs)).await {
+            Ok(result) => Some(result),
+            Err(prompty::InvokerError::Execute(e)) => {
+                eprintln!("LLM error: {e}");
+                None
+            }
+            Err(prompty::InvokerError::Render(e)) => {
+                eprintln!("Template error: {e}");
+                None
+            }
+            Err(prompty::InvokerError::Load(e)) => {
+                eprintln!("Failed to load prompt: {e}");
+                None
+            }
+            Err(e) => {
+                eprintln!("Unexpected error: {e}");
+                None
+            }
+        }
+    }
+    ```
+  </TabItem>
 </Tabs>
 
 ---
@@ -367,6 +437,30 @@ Test loading, rendering, and parsing without making API calls:
     }
     ```
   </TabItem>
+  <TabItem label="Rust">
+    ```rust
+    use prompty;
+
+    #[tokio::test]
+    async fn test_prompt_loads() {
+        prompty::register_defaults();
+        let agent = prompty::load("prompts/chat.prompty").unwrap();
+        assert_eq!(agent.name(), "production-chat");
+        assert_eq!(agent.model().id(), "gpt-4o");
+    }
+
+    #[tokio::test]
+    async fn test_messages_prepared() {
+        prompty::register_defaults();
+        let agent = prompty::load("prompts/chat.prompty").unwrap();
+        let messages = prompty::prepare(
+            &agent,
+            Some(&serde_json::json!({ "question": "Hello" })),
+        ).await.unwrap();
+        assert_eq!(messages[0].role(), "system");
+    }
+    ```
+  </TabItem>
 </Tabs>
 
 ### Integration Tests — Gated by Environment
@@ -418,6 +512,28 @@ Only run when API keys are available:
                 new() { ["question"] = "Say hi" });
             Assert.NotNull(result);
         }
+    }
+    ```
+  </TabItem>
+  <TabItem label="Rust">
+    ```rust
+    use prompty;
+    use serde_json::json;
+
+    #[tokio::test]
+    async fn test_live_chat() {
+        if std::env::var("OPENAI_API_KEY").is_err() {
+            eprintln!("Skipping: OPENAI_API_KEY not set");
+            return;
+        }
+        prompty::register_defaults();
+        prompty_openai::register();
+
+        let result = prompty::invoke_from_path(
+            "prompts/chat.prompty",
+            Some(&json!({ "question": "Say hi" })),
+        ).await.unwrap();
+        assert!(!result.is_empty());
     }
     ```
   </TabItem>
@@ -501,6 +617,25 @@ Stream tokens to the client as they arrive instead of waiting for the full respo
     {
         await foreach (var chunk in stream)
             Console.Write(chunk);
+    }
+    ```
+  </TabItem>
+  <TabItem label="Rust">
+    ```rust
+    use prompty;
+    use prompty_openai;
+    use serde_json::json;
+    use futures::StreamExt;
+
+    let agent = prompty::load("chat.prompty")?;
+    let messages = prompty::prepare(
+        &agent,
+        Some(&json!({ "question": "Write a summary" })),
+    ).await?;
+
+    let mut stream = prompty::run_stream(&agent, &messages).await?;
+    while let Some(chunk) = stream.next().await {
+        print!("{chunk}");
     }
     ```
   </TabItem>

--- a/web/src/content/docs/tutorials/rag-pipeline.mdx
+++ b/web/src/content/docs/tutorials/rag-pipeline.mdx
@@ -43,6 +43,11 @@ completions together into a retrieval-augmented generation (RAG) pipeline.
     dotnet add package Prompty.OpenAI --prerelease
     ```
   </TabItem>
+  <TabItem label="Rust">
+    ```bash
+    cargo add prompty prompty-openai tokio serde_json
+    ```
+  </TabItem>
 </Tabs>
 
 Create a **`.env`** file with your OpenAI key:
@@ -163,6 +168,11 @@ the vectors in a database — here we keep everything in memory:
     Console.WriteLine($"Vector dimensions: {docVectors[0].Count}"); // 1536
     ```
   </TabItem>
+  <TabItem label="Rust">
+    <Aside type="caution">
+      The Rust runtime does not yet support `apiType: embedding`. Use the chat completion portions of this tutorial and a separate embedding service for the retrieval step.
+    </Aside>
+  </TabItem>
 </Tabs>
 
 <Aside type="tip">
@@ -253,11 +263,39 @@ datasets:
     }
     ```
   </TabItem>
+  <TabItem label="Rust">
+    ```rust
+    fn cosine_similarity(a: &[f32], b: &[f32]) -> f32 {
+        let dot: f32 = a.iter().zip(b.iter()).map(|(x, y)| x * y).sum();
+        let norm_a: f32 = a.iter().map(|x| x * x).sum::<f32>().sqrt();
+        let norm_b: f32 = b.iter().map(|x| x * x).sum::<f32>().sqrt();
+        if norm_a == 0.0 || norm_b == 0.0 {
+            return 0.0;
+        }
+        dot / (norm_a * norm_b)
+    }
+
+    fn retrieve(
+        query_vector: &[f32],
+        doc_vectors: &[Vec<f32>],
+        documents: &[&str],
+        top_k: usize,
+    ) -> Vec<String> {
+        let mut scored: Vec<(f32, &str)> = doc_vectors
+            .iter()
+            .zip(documents.iter())
+            .map(|(dv, doc)| (cosine_similarity(query_vector, dv), *doc))
+            .collect();
+        scored.sort_by(|a, b| b.0.partial_cmp(&a.0).unwrap());
+        scored.into_iter().take(top_k).map(|(_, doc)| doc.to_string()).collect()
+    }
+    ```
+  </TabItem>
 </Tabs>
 
 ---
 
-## Step 5: Create the Q&A `.prompty` file
+## Step 5: Create the Q&A`.prompty` file
 
 Create **`rag-qa.prompty`** — a chat prompt that receives retrieved context:
 
@@ -391,6 +429,53 @@ Now connect all the pieces: embed the query → retrieve → inject context → 
 
     Console.WriteLine(await Ask("What are thread inputs?"));
     // → "Thread inputs with kind: thread enable multi-turn conversations..."
+    ```
+  </TabItem>
+  <TabItem label="Rust">
+    <Aside type="caution">
+      The Rust runtime does not yet support `apiType: embedding`. Use the chat completion portions of this tutorial and a separate embedding service for the retrieval step.
+    </Aside>
+
+    ```rust
+    use prompty;
+    use prompty_openai;
+    use serde_json::json;
+
+    // Assumes you have doc_vectors and documents from an external
+    // embedding service, and a retrieve() function as shown above.
+
+    #[tokio::main]
+    async fn main() -> Result<(), Box<dyn std::error::Error>> {
+        prompty::register_defaults();
+        prompty_openai::register();
+
+        let question = "How does the Prompty pipeline work?";
+
+        // 1. Obtain query_vector from your embedding service
+        // let query_vector = my_embedding_service.embed(question).await?;
+
+        // 2. Retrieve relevant documents
+        // let relevant_docs = retrieve(&query_vector, &doc_vectors, &documents, 2);
+        let relevant_docs = vec![
+            "The pipeline has four stages: render, parse, execute, and process.",
+        ];
+        let context = relevant_docs
+            .iter()
+            .map(|doc| format!("- {doc}"))
+            .collect::<Vec<_>>()
+            .join("\n\n");
+
+        // 3. Answer with grounded context
+        let answer = prompty::invoke_from_path(
+            "rag-qa.prompty",
+            Some(&json!({
+                "question": question,
+                "context": context,
+            })),
+        ).await?;
+        println!("{answer}");
+        Ok(())
+    }
     ```
   </TabItem>
 </Tabs>

--- a/web/src/content/docs/tutorials/tool-calling-agent.mdx
+++ b/web/src/content/docs/tutorials/tool-calling-agent.mdx
@@ -42,6 +42,11 @@ and how to add multiple tools to a single agent.
     dotnet add package Prompty.OpenAI --prerelease
     ```
   </TabItem>
+  <TabItem label="Rust">
+    ```bash
+    cargo add prompty prompty-openai tokio serde_json
+    ```
+  </TabItem>
 </Tabs>
 
 Create a **`.env`** file with your OpenAI key:
@@ -151,6 +156,20 @@ Write the function that the agent will call. Use the `@tool` decorator
     }
     ```
   </TabItem>
+  <TabItem label="Rust">
+    ```rust
+    use prompty;
+    use serde_json::json;
+
+    prompty::register_tool_handler("get_weather", |args| {
+        Box::pin(async move {
+            let city = args["city"].as_str().unwrap_or("unknown");
+            // In production, call a real weather API here
+            Ok(json!(format!("72°F and sunny in {city}")))
+        })
+    });
+    ```
+  </TabItem>
 </Tabs>
 
 ---
@@ -227,6 +246,35 @@ loop so the runtime automatically executes your functions:
     // → "The weather in Seattle is 72°F and sunny!"
     ```
   </TabItem>
+  <TabItem label="Rust">
+    ```rust
+    use prompty;
+    use prompty_openai;
+    use serde_json::json;
+
+    #[tokio::main]
+    async fn main() -> Result<(), Box<dyn std::error::Error>> {
+        prompty::register_defaults();
+        prompty_openai::register();
+
+        prompty::register_tool_handler("get_weather", |args| {
+            Box::pin(async move {
+                let city = args["city"].as_str().unwrap_or("unknown");
+                Ok(json!(format!("72°F and sunny in {city}")))
+            })
+        });
+
+        let result = prompty::turn_from_path(
+            "weather-agent.prompty",
+            Some(&json!({ "question": "What's the weather in Seattle?" })),
+            None,
+        ).await?;
+        println!("{result}");
+        // → "The weather in Seattle is 72°F and sunny!"
+        Ok(())
+    }
+    ```
+  </TabItem>
 </Tabs>
 
 <Aside type="tip">
@@ -281,6 +329,20 @@ Register the **console tracer** to watch each step of the agent loop:
         new() { ["question"] = "What's the weather in Seattle?" },
         tools: tools
     );
+    ```
+  </TabItem>
+  <TabItem label="Rust">
+    ```rust
+    use prompty::{Tracer, console_tracer};
+
+    Tracer::register("console", console_tracer);
+
+    // Now run — each step is logged to the console
+    let result = prompty::turn_from_path(
+        "weather-agent.prompty",
+        Some(&json!({ "question": "What's the weather in Seattle?" })),
+        None,
+    ).await?;
     ```
   </TabItem>
 </Tabs>
@@ -416,9 +478,47 @@ Now register both functions:
     Console.WriteLine(result);
     ```
   </TabItem>
+  <TabItem label="Rust">
+    ```rust
+    use prompty;
+    use prompty_openai;
+    use serde_json::json;
+
+    #[tokio::main]
+    async fn main() -> Result<(), Box<dyn std::error::Error>> {
+        prompty::register_defaults();
+        prompty_openai::register();
+
+        prompty::register_tool_handler("get_weather", |args| {
+            Box::pin(async move {
+                let city = args["city"].as_str().unwrap_or("unknown");
+                Ok(json!(format!("72°F and sunny in {city}")))
+            })
+        });
+
+        prompty::register_tool_handler("get_time", |args| {
+            Box::pin(async move {
+                let _tz = args["timezone"].as_str().unwrap_or("UTC");
+                Ok(json!(chrono::Utc::now().to_rfc3339()))
+            })
+        });
+
+        let result = prompty::turn_from_path(
+            "weather-agent.prompty",
+            Some(&json!({
+                "question": "What's the weather in Seattle and the time in Tokyo?"
+            })),
+            None,
+        ).await?;
+        println!("{result}");
+        // The model calls both tools and combines the results
+        Ok(())
+    }
+    ```
+  </TabItem>
 </Tabs>
 
-The model may call both tools in a single round or across multiple rounds —
+The model may call both toolsin a single round or across multiple rounds —
 the agent loop handles either pattern automatically.
 
 ---

--- a/web/src/content/docs/welcome.mdx
+++ b/web/src/content/docs/welcome.mdx
@@ -3,7 +3,7 @@ title: Welcome to Prompty
 description: >
   Prompty is a markdown file format for LLM prompts. Define model config,
   inputs, tools, and templates in YAML frontmatter — then execute across
-  Python, TypeScript, and more.
+  Python, TypeScript, C#, Rust, and more.
 sidebar:
   order: 1
 ---
@@ -12,7 +12,7 @@ import { Aside, Tabs, TabItem, CardGrid, LinkCard } from '@astrojs/starlight/com
 
 **Prompty** is a file format (`.prompty`) for LLM prompts. Write your prompt
 once — model config, inputs, tools, and template in a single markdown file —
-then run it from Python, TypeScript, or C#. Treat prompts as code: version
+then run it from Python, TypeScript, C#, or Rust. Treat prompts as code: version
 them in git, test them in CI, share them across teams, and deploy with
 confidence.
 
@@ -66,6 +66,19 @@ Say hello to {{userName}}.
     var result = await Pipeline.InvokeAsync("greeting.prompty", new() { ["userName"] = "Jane" });
     ```
   </TabItem>
+  <TabItem label="Rust">
+    ```rust
+    use serde_json::json;
+
+    prompty::register_defaults();
+    prompty_openai::register();
+
+    let result = prompty::invoke_from_path(
+        "greeting.prompty",
+        Some(&json!({ "userName": "Jane" })),
+    ).await?;
+    ```
+  </TabItem>
 </Tabs>
 
 ## What Can You Build?
@@ -78,7 +91,7 @@ Say hello to {{userName}}.
 
 ## Key Features
 
-- **Three runtimes** — Python, TypeScript, and C#
+- **Four runtimes** — Python, TypeScript, C#, and Rust
 - **Pipeline architecture** — render → parse → execute → process, each stage swappable
 - **Built-in tracing** — console, JSON file, and OpenTelemetry backends
 - **Provider support** — OpenAI, Azure / Foundry, and Anthropic


### PR DESCRIPTION
## Summary

Two changes in this PR:

### 1. Fix Rust spec compliance (8 violations)

Audited the Rust runtime against \spec/spec.md\ and fixed 8 spec violations:

| Spec Section | Fix |
|---|---|
| §7.1.2 | Audio MIME fallback strips prefix instead of defaulting to wav |
| §8.1 | Anthropic structured output falls back to raw string on parse failure |
| §10.3 | Streaming refusal emits \StreamChunk::Error\ and stops stream |
| §13.1 | Added \StreamChunk::Thinking\ variant + Anthropic thinking events |
| §13.1 | Status event emission for steering injection |
| §13.1 | \messages_updated\ emitted after context trim and steering drain |
| §13.1 | Event callbacks wrapped in \catch_unwind\ for panic safety |
| §13.5 | Steering made thread-safe with \Arc<Mutex<VecDeque>>\ |

All 484 Rust tests pass, clippy and fmt clean.

### 2. Add Rust to documentation site

Adds Rust as a 4th language tab across the entire docs:

- **\implementation/rust.mdx\** — dedicated Rust runtime page
- **\docs-examples/rust/\** — compilable example files
- **126 Rust \<TabItem>\ blocks** across **35 pages**
- Tab order: Python → TypeScript → C# → **Rust**
- Gaps honestly documented (embeddings, images, responses API, MCP/OpenAPI tools)

\
pm run build\ passes — 120 pages, all links valid.