### PR TITLE
fix(csharp): prevent symlink escapes in file references

### DIFF
--- a/runtime/csharp/Prompty.Anthropic/Prompty.Anthropic.csproj
+++ b/runtime/csharp/Prompty.Anthropic/Prompty.Anthropic.csproj
@@ -4,7 +4,7 @@
     <TargetFramework>net9.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
-    <Version>2.0.0-beta.3</Version>
+    <Version>2.0.0-beta.4</Version>
     <PackageId>Prompty.Anthropic</PackageId>
     <Authors>Microsoft</Authors>
     <Description>Anthropic provider for Prompty — executor and processor for Claude models via the Anthropic Messages API.</Description>

--- a/runtime/csharp/Prompty.Core.Tests/LoaderTests.cs
+++ b/runtime/csharp/Prompty.Core.Tests/LoaderTests.cs
@@ -371,6 +371,29 @@ public class LoaderTests
         }
     }
 
+    [Fact]
+    public async Task LoadAsync_FileRef_IntermediateDirectorySymlinkEscape_Throws()
+    {
+        var root = Directory.CreateTempSubdirectory("prompty-loader-");
+        try
+        {
+            var promptDir = Directory.CreateDirectory(Path.Combine(root.FullName, "prompts"));
+            var externalDir = Directory.CreateDirectory(Path.Combine(root.FullName, "external"));
+            File.WriteAllText(Path.Combine(externalDir.FullName, "secret.txt"), "secret");
+            Directory.CreateSymbolicLink(Path.Combine(promptDir.FullName, "assets"), externalDir.FullName);
+
+            var prompt = Path.Combine(promptDir.FullName, "bad.prompty");
+            File.WriteAllText(prompt, "---\nname: bad\ndescription: \"${file:assets/secret.txt}\"\n---\nHello\n");
+
+            var ex = await Assert.ThrowsAsync<InvalidOperationException>(() => PromptyLoader.LoadAsync(prompt));
+            Assert.Contains("outside allowed roots", ex.Message);
+        }
+        finally
+        {
+            root.Delete(recursive: true);
+        }
+    }
+
     // --- Tools ---
 
     [Fact]

--- a/runtime/csharp/Prompty.Core.Tests/LoaderTests.cs
+++ b/runtime/csharp/Prompty.Core.Tests/LoaderTests.cs
@@ -348,6 +348,29 @@ public class LoaderTests
         }
     }
 
+    [Fact]
+    public void Load_FileRef_IntermediateDirectorySymlinkEscape_Throws()
+    {
+        var root = Directory.CreateTempSubdirectory("prompty-loader-");
+        try
+        {
+            var promptDir = Directory.CreateDirectory(Path.Combine(root.FullName, "prompts"));
+            var externalDir = Directory.CreateDirectory(Path.Combine(root.FullName, "external"));
+            File.WriteAllText(Path.Combine(externalDir.FullName, "secret.txt"), "secret");
+            Directory.CreateSymbolicLink(Path.Combine(promptDir.FullName, "assets"), externalDir.FullName);
+
+            var prompt = Path.Combine(promptDir.FullName, "bad.prompty");
+            File.WriteAllText(prompt, "---\nname: bad\ndescription: \"${file:assets/secret.txt}\"\n---\nHello\n");
+
+            var ex = Assert.Throws<InvalidOperationException>(() => PromptyLoader.Load(prompt));
+            Assert.Contains("outside allowed roots", ex.Message);
+        }
+        finally
+        {
+            root.Delete(recursive: true);
+        }
+    }
+
     // --- Tools ---
 
     [Fact]

--- a/runtime/csharp/Prompty.Core/Prompty.Core.csproj
+++ b/runtime/csharp/Prompty.Core/Prompty.Core.csproj
@@ -4,7 +4,7 @@
     <TargetFramework>net9.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
-    <Version>2.0.0-beta.3</Version>
+    <Version>2.0.0-beta.4</Version>
     <PackageId>Prompty.Core</PackageId>
     <Authors>Microsoft</Authors>
     <Description>Prompty is an asset class and format for LLM prompts. Core library with loader, pipeline, renderers, parsers, and tracing.</Description>

--- a/runtime/csharp/Prompty.Core/ReferenceResolver.cs
+++ b/runtime/csharp/Prompty.Core/ReferenceResolver.cs
@@ -171,18 +171,42 @@ public static class ReferenceResolver
     private static string GetCanonicalPath(string path)
     {
         var fullPath = Path.GetFullPath(path);
-        if (File.Exists(fullPath))
+        var root = Path.GetPathRoot(fullPath);
+        if (string.IsNullOrEmpty(root))
         {
-            var file = new FileInfo(fullPath);
-            var target = file.ResolveLinkTarget(returnFinalTarget: true);
-            return Path.GetFullPath(target?.FullName ?? file.FullName);
+            return fullPath;
         }
-        if (Directory.Exists(fullPath))
+
+        var canonicalPath = root;
+        var components = fullPath[root.Length..].Split(
+            [Path.DirectorySeparatorChar, Path.AltDirectorySeparatorChar],
+            StringSplitOptions.RemoveEmptyEntries);
+
+        foreach (var component in components)
         {
-            var directory = new DirectoryInfo(fullPath);
-            var target = directory.ResolveLinkTarget(returnFinalTarget: true);
-            return Path.GetFullPath(target?.FullName ?? directory.FullName);
+            canonicalPath = Path.Combine(canonicalPath, component);
+            var target = ResolveLinkTarget(canonicalPath);
+            if (target is not null)
+            {
+                canonicalPath = Path.GetFullPath(target.FullName);
+            }
         }
-        return fullPath;
+
+        return canonicalPath;
+    }
+
+    private static FileSystemInfo? ResolveLinkTarget(string path)
+    {
+        if (Directory.Exists(path))
+        {
+            return new DirectoryInfo(path).ResolveLinkTarget(returnFinalTarget: true);
+        }
+
+        if (File.Exists(path))
+        {
+            return new FileInfo(path).ResolveLinkTarget(returnFinalTarget: true);
+        }
+
+        return null;
     }
 }

--- a/runtime/csharp/Prompty.Foundry/Prompty.Foundry.csproj
+++ b/runtime/csharp/Prompty.Foundry/Prompty.Foundry.csproj
@@ -6,7 +6,7 @@
     <Nullable>enable</Nullable>
     <NoWarn>OPENAI001;CS1591</NoWarn>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
-    <Version>2.0.0-beta.3</Version>
+    <Version>2.0.0-beta.4</Version>
     <PackageId>Prompty.Foundry</PackageId>
     <Authors>Microsoft</Authors>
     <Description>Microsoft Foundry (Azure OpenAI) provider for Prompty — executor and processor for Azure-hosted models.</Description>

--- a/runtime/csharp/Prompty.OpenAI/Prompty.OpenAI.csproj
+++ b/runtime/csharp/Prompty.OpenAI/Prompty.OpenAI.csproj
@@ -6,7 +6,7 @@
     <Nullable>enable</Nullable>
     <NoWarn>OPENAI001;CS1591</NoWarn>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
-    <Version>2.0.0-beta.3</Version>
+    <Version>2.0.0-beta.4</Version>
     <PackageId>Prompty.OpenAI</PackageId>
     <Authors>Microsoft</Authors>
     <Description>OpenAI provider for Prompty — executor and processor for OpenAI chat, embedding, image, and agent APIs.</Description>


### PR DESCRIPTION
## Summary
- canonicalize every path component before validating \ containment
- reject intermediate directory symlink and junction escapes in sync and async loaders
- release the coordinated C# package set as 2.0.0-beta.4

Fixes GHSA-w28w-gp39-m4p6.