### PR TITLE
fix(promptyjs): restrict Nunjucks template execution

### DIFF
--- a/.github/workflows/prompty-js.yml
+++ b/.github/workflows/prompty-js.yml
@@ -42,6 +42,7 @@ jobs:
 
   publish-artifacts:
     name: publish artifacts
+    if: github.event_name == 'push' && github.ref == 'refs/heads/v1'
     needs: prompty-tests
     runs-on: ubuntu-latest
     permissions:

--- a/runtime/promptyjs/package-lock.json
+++ b/runtime/promptyjs/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "promptyjs",
-  "version": "0.1.0",
+  "version": "0.1.5",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "promptyjs",
-      "version": "0.1.0",
+      "version": "0.1.5",
       "license": "ISC",
       "dependencies": {
         "base-64": "^1.0.0",

--- a/runtime/promptyjs/package.json
+++ b/runtime/promptyjs/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@prompty/core",
-  "version": "0.1.4",
+  "version": "0.1.5",
   "description": "Prompty core package",
   "main": "./dist/index.js",
   "module": "./dist/index.mjs",

--- a/runtime/promptyjs/src/renderers.ts
+++ b/runtime/promptyjs/src/renderers.ts
@@ -3,6 +3,98 @@ import { Invoker, InvokerFactory } from "./invokerFactory";
 import * as nunjucks from 'nunjucks';
 import * as mustache from 'mustache'
 
+type NunjucksRuntime = {
+    contextOrFrameLookup: (context: unknown, frame: unknown, name: unknown) => unknown;
+    memberLookup: (object: unknown, property: unknown) => unknown;
+    callWrap: (callable: unknown, name: string, context: unknown, args: unknown[]) => unknown;
+};
+
+const UNSAFE_PROPERTIES = new Set(["__proto__", "constructor", "prototype"]);
+
+function safeMemberLookup(object: unknown, property: unknown): unknown {
+    if (typeof property === "string" && UNSAFE_PROPERTIES.has(property)) {
+        throw new Error(`Unsafe template member access: ${property}`);
+    }
+
+    if (
+        (typeof property !== "string" && typeof property !== "number") ||
+        object === null ||
+        typeof object !== "object"
+    ) {
+        return undefined;
+    }
+
+    const descriptor = Object.getOwnPropertyDescriptor(object, property);
+    return descriptor !== undefined && "value" in descriptor ? descriptor.value : undefined;
+}
+
+function safeCallWrap(_callable: unknown, name: string, _context: unknown, _args: unknown[]): never {
+    throw new Error(`Template function calls are not allowed: ${name}`);
+}
+
+function sanitizeValue(value: unknown, seen = new WeakMap<object, unknown>()): unknown {
+    if (value === null || typeof value === "string" || typeof value === "number" || typeof value === "boolean") {
+        return value;
+    }
+
+    if (typeof value !== "object") {
+        return undefined;
+    }
+
+    const existing = seen.get(value);
+    if (existing !== undefined) {
+        return existing;
+    }
+
+    if (Array.isArray(value)) {
+        const result: unknown[] = [];
+        seen.set(value, result);
+        for (const item of value) {
+            result.push(sanitizeValue(item, seen));
+        }
+        return result;
+    }
+
+    const result = Object.create(null) as Record<string, unknown>;
+    seen.set(value, result);
+    for (const [key, descriptor] of Object.entries(Object.getOwnPropertyDescriptors(value))) {
+        if (!UNSAFE_PROPERTIES.has(key) && "value" in descriptor) {
+            result[key] = sanitizeValue(descriptor.value, seen);
+        }
+    }
+    return result;
+}
+
+function sanitizeInputs(inputs: unknown): Record<string, unknown> {
+    const sanitized = sanitizeValue(inputs);
+    return sanitized !== null && typeof sanitized === "object" && !Array.isArray(sanitized)
+        ? sanitized as Record<string, unknown>
+        : Object.create(null);
+}
+
+function renderSafely(template: string, inputs: Record<string, unknown>): string {
+    const runtime = nunjucks.runtime as unknown as NunjucksRuntime;
+    const contextOrFrameLookup = runtime.contextOrFrameLookup;
+    const memberLookup = runtime.memberLookup;
+    const callWrap = runtime.callWrap;
+    runtime.contextOrFrameLookup = (context, frame, name) => {
+        if (typeof name === "string" && UNSAFE_PROPERTIES.has(name)) {
+            throw new Error(`Unsafe template member access: ${name}`);
+        }
+        return contextOrFrameLookup(context, frame, name);
+    };
+    runtime.memberLookup = safeMemberLookup;
+    runtime.callWrap = safeCallWrap;
+
+    try {
+        return nunjucks.renderString(template, inputs);
+    } finally {
+        runtime.contextOrFrameLookup = contextOrFrameLookup;
+        runtime.memberLookup = memberLookup;
+        runtime.callWrap = callWrap;
+    }
+}
+
 class NunjucksRenderer extends Invoker {
     private templates: Record<string, string> = {};
     //private name: string;
@@ -12,7 +104,7 @@ class NunjucksRenderer extends Invoker {
     }
 
     invokeSync(data: any): any {
-        return nunjucks.renderString(this.prompty.content, data);
+        return renderSafely(this.prompty.content, sanitizeInputs(data));
     }
 }
 

--- a/runtime/promptyjs/tests/security.test.ts
+++ b/runtime/promptyjs/tests/security.test.ts
@@ -1,4 +1,5 @@
 import { Prompty } from "../src/core";
+import { InvokerFactory } from "../src/invokerFactory";
 
 describe("Security Tests", () => {
   test("should not execute JavaScript in front matter", () => {
@@ -49,5 +50,60 @@ This is safe content.`;
     expect(prompt.name).toBe("");
     expect(prompt.description).toBe("");
     expect(prompt.content).toBe(simpleContent);
+  });
+
+  test("renders normal interpolation, conditionals, loops, and nested own properties", () => {
+    const prompt = new Prompty(
+      "{% if customer.active %}{% for item in customer.items %}{{ customer.name }}: {{ item }} {% endfor %}{% endif %}"
+    );
+
+    const result = InvokerFactory.getInstance().callRendererSync(prompt, {
+      customer: {
+        active: true,
+        items: ["one", "two"],
+        name: "Ada",
+      },
+    });
+
+    expect(result.trim()).toBe("Ada: one Ada: two");
+  });
+
+  test.each(["{{ value.constructor }}", "{{ value.__proto__ }}", "{{ value.prototype }}"])(
+    "rejects unsafe Nunjucks member access: %s",
+    (template) => {
+      const prompt = new Prompty(template);
+
+      expect(() => InvokerFactory.getInstance().callRendererSync(prompt, { value: "test" }))
+        .toThrow("Unsafe template member access");
+    }
+  );
+
+  test.each(["{{ constructor }}", "{{ __proto__ }}", "{{ prototype }}"])(
+    "rejects unsafe Nunjucks root access: %s",
+    (template) => {
+      const prompt = new Prompty(template);
+
+      expect(() => InvokerFactory.getInstance().callRendererSync(prompt, {}))
+        .toThrow("Unsafe template member access");
+    }
+  );
+
+  test("does not evaluate inherited or accessor input properties", () => {
+    const inputs = Object.create({ inherited: "secret" });
+    const getter = jest.fn(() => "secret");
+    Object.defineProperty(inputs, "accessor", { get: getter });
+    const prompt = new Prompty("{{ inherited }}{{ accessor }}");
+
+    expect(InvokerFactory.getInstance().callRendererSync(prompt, inputs)).toBe("");
+    expect(getter).not.toHaveBeenCalled();
+  });
+
+  test("rejects template function calls without invoking input functions", () => {
+    const callback = jest.fn();
+    const prompt = new Prompty("{{ callback() }}");
+
+    expect(() => InvokerFactory.getInstance().callRendererSync(prompt, { callback }))
+      .toThrow("Template function calls are not allowed");
+    expect(callback).not.toHaveBeenCalled();
   });
 });


### PR DESCRIPTION
## Summary
- backport Nunjucks SSTI/RCE protections to legacy @prompty/core 0.1.x
- sanitize inputs, reject prototype traversal, and prohibit template function calls
- add regression coverage and release @prompty/core 0.1.5 only after merge to v1

Fixes GHSA-w28w-gp39-m4p6 legacy package range.