### PR TITLE
ci(promptyjs): pin npm for Node 20 publish

### DIFF
--- a/.github/workflows/prompty-js.yml
+++ b/.github/workflows/prompty-js.yml
@@ -54,8 +54,8 @@ jobs:
         uses: actions/setup-node@v4
         with:
           node-version: "20.x"
-      - name: Ensure latest npm
-        run: npm install -g npm@latest
+      - name: Ensure Node 20-compatible npm
+        run: npm install -g npm@10
       - name: Node.js install dependencies
         working-directory: ./runtime/promptyjs
         run: npm ci


### PR DESCRIPTION
## Summary
- pin the publish workflow to npm 10, which supports the workflow's Node 20 runner
- prevent npm 12 from being selected by the unpinned global upgrade

## Validation
- parsed .github/workflows/prompty-js.yml with js-yaml
- verified npm@10 declares Node ^18.17.0 || >=20.5.0 support