### PR TITLE
ci(promptyjs): allow v1 manual publishing

### DIFF
--- a/.github/workflows/prompty-js.yml
+++ b/.github/workflows/prompty-js.yml
@@ -42,7 +42,7 @@ jobs:
 
   publish-artifacts:
     name: publish artifacts
-    if: github.event_name == 'push' && github.ref == 'refs/heads/v1'
+    if: github.ref == 'refs/heads/v1' && (github.event_name == 'push' || github.event_name == 'workflow_dispatch')
     needs: prompty-tests
     runs-on: ubuntu-latest
     permissions:


### PR DESCRIPTION
## Summary
- allow the npm publish job on v1 manual workflow dispatches
- retain publication for v1 pushes only; feature-branch pushes remain blocked

## Validation
- parsed .github/workflows/prompty-js.yml with js-yaml
- checked the v1 push/dispatch guard truth table