### PR TITLE
ci(promptyjs): pin trusted publishing npm

### DIFF
--- a/.github/workflows/prompty-js.yml
+++ b/.github/workflows/prompty-js.yml
@@ -54,8 +54,8 @@ jobs:
         uses: actions/setup-node@v4
         with:
           node-version: "20.x"
-      - name: Ensure Node 20-compatible npm
-        run: npm install -g npm@10
+      - name: Ensure trusted-publishing compatible npm
+        run: npm install -g npm@11.6.4
       - name: Node.js install dependencies
         working-directory: ./runtime/promptyjs
         run: npm ci


### PR DESCRIPTION
## Summary
- pin the established v1 npm trusted-publisher workflow to npm 11.6.4
- retain Node 20, the v1 push/manual-dispatch guard, and OIDC permissions
- use the workflow path that previously published @prompty/core 0.1.4

## Validation
- parsed and structurally validated .github/workflows/prompty-js.yml`n- verified npm 11.6.4 supports Node ^20.17.0