### PR TITLE
ci(promptyjs): isolate v1 OIDC publishing

### DIFF
--- a/.github/workflows/prompty-js.yml
+++ b/.github/workflows/prompty-js.yml
@@ -19,8 +19,6 @@ jobs:
     permissions:
       # This permission is needed for private repositories.
       contents: read
-      # IMPORTANT: this permission is mandatory for trusted publishing
-      id-token: write
     steps:
       - uses: actions/checkout@v4
       - name: Setup Node.js ${{ matrix.node-version }}
@@ -39,29 +37,3 @@ jobs:
       - name: Node.js test
         working-directory: ./runtime/promptyjs
         run: npm run test
-
-  publish-artifacts:
-    name: publish artifacts
-    if: github.ref == 'refs/heads/v1' && (github.event_name == 'push' || github.event_name == 'workflow_dispatch')
-    needs: prompty-tests
-    runs-on: ubuntu-latest
-    permissions:
-      id-token: write
-      contents: read
-    steps:
-      - uses: actions/checkout@v4
-      - name: Setup Node.js
-        uses: actions/setup-node@v4
-        with:
-          node-version: "20.x"
-      - name: Ensure trusted-publishing compatible npm
-        run: npm install -g npm@11.6.4
-      - name: Node.js install dependencies
-        working-directory: ./runtime/promptyjs
-        run: npm ci
-      - name: Node.js build
-        working-directory: ./runtime/promptyjs
-        run: npm run build --if-present
-      - name: Publish package
-        working-directory: ./runtime/promptyjs
-        run: npm publish --provenance --access public

--- a/.github/workflows/prompty-ts-release.yml
+++ b/.github/workflows/prompty-ts-release.yml
@@ -37,9 +37,9 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v4
         with:
-          node-version: "20.x"
+          node-version: "24.x"
           registry-url: https://registry.npmjs.org
-      - run: npm install -g npm@10
+      - run: npm install -g npm@11.6.4
       - run: npm ci
       - name: Verify package version
         run: test "$(node -p "require('./package.json').version")" = "0.1.5"


### PR DESCRIPTION
## Summary
- make .github/workflows/prompty-ts-release.yml the sole v1 publishing workflow, sharing v2's trusted-publisher filename without changing main
- use Node 24/npm 11.6.4 exclusively for the OIDC publish job; retain Node 20/npm 10 for prerequisites
- remove the legacy JavaScript workflow publish job to prevent duplicate releases

## Validation
- parsed both workflow files with js-yaml
- validated ref gates, OIDC permissions, runtimes, npm pins, and removed legacy publisher