### PR TITLE
ci(promptyjs): rename v1 test workflow

### DIFF
--- a/.github/workflows/prompty-js.yml
+++ b/.github/workflows/prompty-js.yml
@@ -1,4 +1,4 @@
-name: prompty JavaScript build and publish
+name: prompty JavaScript build and test
 
 on:
   push:


### PR DESCRIPTION
Rename the legacy JavaScript workflow to reflect that publishing now occurs exclusively through the separate OIDC release workflow. No behavior changes.