### PR TITLE
fix(rust): report token usage on Foundry streaming turns (follow-up to #428)

### DIFF
--- a/runtime/rust/prompty-foundry/src/executor.rs
+++ b/runtime/rust/prompty-foundry/src/executor.rs
@@ -113,10 +113,9 @@ impl Executor for FoundryExecutor {
 
         let mut body = wire::build_chat_args(agent, messages)
             .map_err(|error| InvokerError::Validation(error.to_string()))?;
-        // Force stream: true
-        if let Some(obj) = body.as_object_mut() {
-            obj.insert("stream".into(), Value::Bool(true));
-        }
+        // Force stream: true and request terminal usage so the done event
+        // reports token counts (Azure omits usage from the stream otherwise).
+        wire::enable_streaming(&mut body, api_type);
 
         let (url, auth_header) = build_azure_request(agent, api_type).await?;
 

--- a/runtime/rust/prompty-openai/src/executor.rs
+++ b/runtime/rust/prompty-openai/src/executor.rs
@@ -193,15 +193,7 @@ impl OpenAIExecutor {
         };
 
         // Force stream: true
-        if let Some(obj) = body.as_object_mut() {
-            obj.insert("stream".into(), Value::Bool(true));
-            if matches!(api_type, "chat" | "agent") {
-                obj.insert(
-                    "stream_options".into(),
-                    serde_json::json!({ "include_usage": true }),
-                );
-            }
-        }
+        wire::enable_streaming(&mut body, api_type);
 
         let api_key = get_api_key(agent)?;
         let client = &*HTTP_CLIENT;

--- a/runtime/rust/prompty-openai/src/lib.rs
+++ b/runtime/rust/prompty-openai/src/lib.rs
@@ -23,7 +23,7 @@ pub use processor::{
 };
 pub use wire::{
     SchemaError, build_chat_args, build_embedding_args, build_image_args, build_responses_args,
-    format_tool_messages, message_to_wire, tools_to_wire,
+    enable_streaming, format_tool_messages, message_to_wire, tools_to_wire,
 };
 
 /// Register the OpenAI executor and processor in the global registry.

--- a/runtime/rust/prompty-openai/src/wire.rs
+++ b/runtime/rust/prompty-openai/src/wire.rs
@@ -153,6 +153,25 @@ pub fn build_chat_args(agent: &Prompty, messages: &[Message]) -> Result<Value, S
     Ok(Value::Object(args))
 }
 
+/// Enable server-sent streaming on a chat/agent request body.
+///
+/// Sets `stream: true` and, for the `chat` and `agent` API types, adds
+/// `stream_options: { include_usage: true }` so the terminal stream event
+/// carries token usage. Providers that speak the OpenAI wire format (OpenAI
+/// and Foundry/Azure OpenAI) share this helper so their streaming requests —
+/// and therefore the usage reported on their done events — stay identical.
+pub fn enable_streaming(body: &mut Value, api_type: &str) {
+    if let Some(obj) = body.as_object_mut() {
+        obj.insert("stream".to_string(), Value::Bool(true));
+        if matches!(api_type, "chat" | "agent") {
+            obj.insert(
+                "stream_options".to_string(),
+                serde_json::json!({ "include_usage": true }),
+            );
+        }
+    }
+}
+
 /// Build the request body for an embedding call.
 pub fn build_embedding_args(agent: &Prompty, messages: &[Message]) -> Value {
     let model = if agent.model.id.is_empty() {
@@ -893,6 +912,30 @@ mod tests {
         let wire = message_to_wire(&msg);
         assert_eq!(wire["role"], "user");
         assert_eq!(wire["content"], "Hello");
+    }
+
+    #[test]
+    fn test_enable_streaming_chat_includes_usage() {
+        let mut body = serde_json::json!({ "model": "gpt-4" });
+        enable_streaming(&mut body, "chat");
+        assert_eq!(body["stream"], true);
+        assert_eq!(body["stream_options"]["include_usage"], true);
+    }
+
+    #[test]
+    fn test_enable_streaming_agent_includes_usage() {
+        let mut body = serde_json::json!({ "model": "gpt-4" });
+        enable_streaming(&mut body, "agent");
+        assert_eq!(body["stream"], true);
+        assert_eq!(body["stream_options"]["include_usage"], true);
+    }
+
+    #[test]
+    fn test_enable_streaming_other_api_type_omits_usage() {
+        let mut body = serde_json::json!({ "model": "gpt-4" });
+        enable_streaming(&mut body, "responses");
+        assert_eq!(body["stream"], true);
+        assert!(body.get("stream_options").is_none());
     }
 
     #[test]


### PR DESCRIPTION
Follow-up to #428 (Foundry/OpenAI model discovery + unified turn engine).

## Problem
Foundry/Azure OpenAI **streaming** chat turns reported `total_tokens=0`. The `prompty-foundry` streaming executor set `stream: true` but never requested terminal usage, so Azure omits the usage chunk and no `StreamChunk::Usage` is ever produced. The `prompty-openai` executor already sent `stream_options: { include_usage: true }` — the two providers had diverged.

## Fix
Extract a shared `wire::enable_streaming(body, api_type)` helper (in `prompty_openai::wire`, which `prompty-foundry` already imports) now called by **both** executors, so their streaming requests — and the usage on their done events — stay identical. Sets `stream: true` and, for `chat`/`agent` api types, `stream_options.include_usage=true` (guarded so the Responses path is unaffected). Parse side unchanged (already correct).

## Tests
Added 3 `wire` unit tests (chat/agent request usage; other api types omit it). Verified: `prompty-openai` 80 tests + `prompty-foundry` green, clippy clean on **stable 1.97 and 1.85 MSRV**, `cargo fmt` clean.

Validated end-to-end by the CutReady turn-engine pressure test, which independently root-caused the same divergence.
