### PR TITLE
ci(schema): gate that generated code matches the pinned @typra/emitter

### DIFF
--- a/.github/workflows/schema-repro-check.yml
+++ b/.github/workflows/schema-repro-check.yml
@@ -1,0 +1,265 @@
+name: schema generated-code reproducibility
+
+# Asserts that the generated code committed under runtime/* is exactly what the
+# pinned @typra/emitter (schema/package.json) plus the repo's formatters produce.
+#
+# Nothing enforced this before. Every runtime workflow is paths-filtered to
+# runtime/<lang>/**, so a commit touching only schema/ — including one that bumps
+# the emitter pin — triggered ZERO CI. That is not hypothetical: 00a040fb (0.4.26)
+# and 38c7a5a0 (0.4.27) both moved the pin with no regeneration and no job. Both
+# happened to be no-ops, but nothing checked, and the ambiguity cost real time to
+# settle because the only way to know was to run the generator.
+#
+# The trigger paths deliberately extend past schema/**. The drift this gate found
+# on its first run did not come from the emitter at all: #465 regenerated
+# runtime/typescript/package-lock.json for a security audit, which moved prettier
+# 3.8.3 -> 3.9.6, and 3.9.6 formats short union type aliases differently. The
+# generated code was formatted by 3.8.3 and no existing job could see the
+# difference (packages/core's `lint` is `tsc --noEmit`, not a format check). If
+# this gate only watched schema/**, that bump would have landed silently and then
+# failed the next unrelated schema PR, blaming the wrong change. So the manifests
+# that pin the formatters are watched too.
+on:
+  pull_request:
+    paths:
+      # schema/** covers the highest-value trigger of all, schema/package-lock.json:
+      # that is the @typra/emitter pin itself, the thing this gate exists to police.
+      - 'schema/**'
+      - '.github/workflows/schema-repro-check.yml'
+      # Formatter-defining manifests: a bump here changes generated output just as
+      # surely as an emitter bump does, so it must be caught in the PR that causes it.
+      - 'runtime/typescript/package.json'       # prettier / eslint range
+      - 'runtime/typescript/package-lock.json'  # prettier / eslint resolved versions
+      - 'runtime/python/prompty/pyproject.toml' # ruff version + [tool.ruff] config
+      - 'runtime/python/prompty/uv.lock'
+      - 'runtime/go/prompty/go.mod'             # gofmt is toolchain-tied; go-version-file below
+      - '.editorconfig'                         # consumed by dotnet format
+      # Hand-written C# is a real input to this check, unlike the other languages.
+      # The C# driver runs `dotnet format <csproj>` over the WHOLE project, so every
+      # file in these two projects must already be dotnet format-clean or regeneration
+      # rewrites it. (Python/Go/TypeScript drivers only format their emitted output
+      # directories, so hand-written code in those runtimes cannot dirty this check.)
+      # These are the two projects the emitter emits into, per schema/tspconfig.yaml.
+      # Without these paths a C# PR could merge non-format-clean and then redden the
+      # next unrelated schema PR — which is exactly what happened during this PR:
+      # #472 landed on main and the gate correctly failed on the merge commit.
+      - 'runtime/csharp/Prompty.Core/**'
+      - 'runtime/csharp/Prompty.Core.Tests/**'
+
+  workflow_call:
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  regenerate-is-idempotent:
+    name: regeneration produces no diff
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    env:
+      # runtime/python/prompty/uv.lock is tracked and the Python emitter shells out
+      # to `uv run ruff`, which may otherwise re-lock and dirty the tree — which
+      # would report here as generated-code staleness. Frozen turns that into an
+      # explicit lockfile error instead of a misattributed diff.
+      UV_FROZEN: '1'
+    steps:
+      - uses: actions/checkout@v7
+
+      # EVERY toolchain below is pinned to an exact version, deliberately.
+      # Path triggers can only catch formatter versions pinned by files in the repo.
+      # A floating toolchain (`@stable`, `9.0.x`, `node-version: 22`) drifts with no
+      # repo change at all, so no path filter can catch it — it would just fail on
+      # some unrelated contributor's schema PR and blame the wrong change, which is
+      # the exact misattribution this gate exists to prevent. Pinned, a formatter
+      # bump becomes a deliberate one-line change that arrives WITH its regeneration
+      # commit. Please do not "helpfully" restore floating versions here.
+      # These values are the ones that produced the verified-green first run.
+      #
+      # KNOWN LIMITATION, accepted deliberately. Pinning here fixes CI-side drift but
+      # introduces a second-order skew: a developer running `cargo fmt` on rustup
+      # stable, or `dotnet format` on whichever SDK they have, can produce output this
+      # job rejects. Workflow pins bind CI only. The durable instrument is a root
+      # `rust-toolchain.toml` plus a committed `global.json`, which rustup, rustc,
+      # `dtolnay/rust-toolchain` and the .NET CLI all honour — making local and CI
+      # agree by construction instead of by coincidence. That changes the toolchain
+      # for every Rust and C# developer in this repo, so it belongs in its own PR
+      # with its own review, not as a rider on a CI change. Until then, if this gate
+      # disagrees with your local formatter, check these versions first.
+      - uses: actions/setup-node@v7
+        with:
+          node-version: '22.23.2'
+
+      # Generation is only reproducible when EVERY formatter the emitter shells out
+      # to is present. Each one degrades to a console warning when missing rather
+      # than failing, and the resulting unformatted output is indistinguishable in a
+      # diff from stale generated code. Measured on this repo at emitter 0.8.7:
+      # regenerating with prettier, uv, dotnet and Go hidden from PATH produced
+      # 1121 changed files / 47434 insertions, versus 5 files for the genuine drift.
+      # A previous version of this gate was misread exactly that way.
+      #
+      # @typra/emitter 0.8.7 invokes, per emit target in schema/tspconfig.yaml:
+      #   rustfmt   schema's `generate` script ends in `npm run format:rust`
+      #             (`cargo fmt --all`). The Rust driver's own `cargo fmt` never
+      #             runs here — it looks for <output-dir>/../Cargo.toml, i.e.
+      #             runtime/rust/prompty/src/Cargo.toml, which does not exist — and
+      #             it is silent about that. It does not matter: measured with cargo
+      #             removed from PATH, `npm run generate` exits 1 ("'cargo' is not
+      #             recognized") before anything is compared, so rustfmt is the one
+      #             formatter that CANNOT produce silent false staleness. (Had it
+      #             degraded quietly it would have been worth 295 unformatted Rust
+      #             files.) It is still in the warning grep below, harmlessly.
+      #   prettier  typescript/driver.js walks up from the TypeScript project root
+      #             for node_modules/prettier/bin/prettier.cjs, then `npx eslint --fix`
+      #   ruff      python/driver.js runs `uv run ruff check --fix` and `uv run ruff format`
+      #   dotnet    csharp/driver.js runs `dotnet format <csproj>`
+      #   gofmt     go/driver.js runs `gofmt -w` (and `goimports -w` if present)
+      - name: Install Rust toolchain (provides rustfmt)
+        uses: dtolnay/rust-toolchain@master
+        with:
+          toolchain: '1.97.1'
+          components: rustfmt
+
+      - name: Set up Go (provides gofmt)
+        uses: actions/setup-go@v7
+        with:
+          # Pinned via go.mod rather than a literal here: go.mod is the single source
+          # of truth for the Go toolchain and is itself a trigger path above, so a
+          # bump is still deliberate and reviewable, without a second copy to drift.
+          go-version-file: runtime/go/prompty/go.mod
+          cache: false
+
+      - name: Set up .NET (provides dotnet format)
+        uses: actions/setup-dotnet@v6
+        with:
+          dotnet-version: '9.0.317'
+
+      - name: Install TypeScript workspace (provides prettier and eslint)
+        working-directory: runtime/typescript
+        run: npm ci
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@v10.0.1
+
+      - name: Install Python dev tooling (provides ruff)
+        working-directory: runtime/python/prompty
+        run: |
+          uv venv
+          uv pip install -e ".[dev]"
+
+      - name: Install schema dependencies
+        working-directory: schema
+        run: npm ci
+
+      # setup-dotnet's `dotnet-version` installs an SDK, it does NOT select one.
+      # Measured on the previous run of this workflow: with `dotnet-version: 9.0.317`
+      # the image still resolved `dotnet --version` to 10.0.302, because it carries
+      # eleven SDKs (8.0.129 through 10.0.302) and absent a global.json the highest
+      # wins. The pin alone was doing nothing for `dotnet format`, leaving it the one
+      # formatter that could still float with no repo change at all.
+      #
+      # 9.0.317, matching the net9.0 target of every csproj under runtime/csharp/ and
+      # the `9.0.x` that prompty-csharp-check.yml, prompty-csharp.yml and
+      # docs-examples.yml already pin, so this gate does not disagree with the rest of
+      # the repo about which SDK is authoritative.
+      #
+      # Honest caveat, measured: no SDK-dependent difference has been observed on this
+      # tree. 9.0.317, 10.0.111 and 10.0.302 all produced byte-identical output (the
+      # same git blob) for the one file where formatting was ever in question. The pin
+      # is therefore precautionary — it makes the SDK an explicit, reviewable input
+      # rather than a property of whatever image the runner happens to boot.
+      #
+      # This global.json is written here and deleted before the diff assertion — it is
+      # deliberately NOT committed, because a repo-root global.json would constrain
+      # every other .NET job and build in the repo, which is a much larger decision.
+      # rollForward: disable means a future image that drops 9.0.317 fails loudly with
+      # "requested SDK not found" — unambiguous and attributable — rather than silently
+      # formatting with a new SDK and reporting the result as generated-code drift.
+
+      # Pin the SDK that dotnet format will use
+      - name: Pin the SDK that dotnet format will use
+        shell: bash
+        run: |
+          cat > global.json <<'JSON'
+          {
+            "sdk": {
+              "version": "9.0.317",
+              "rollForward": "disable"
+            }
+          }
+          JSON
+
+      # Record every version that can change the output. When this gate goes red,
+      # formatter?" — this makes that answerable from the log alone instead of by
+      # bisecting. It is also where the SDK actually selected by `dotnet format`
+      # becomes visible, which is how the pin above was found to be a no-op.
+      - name: Record toolchain versions
+        shell: bash
+        run: |
+          echo "node      $(node --version)"
+          echo "rustc     $(rustc --version)"
+          echo "rustfmt   $(rustfmt --version)"
+          echo "go        $(go version)"
+          echo "dotnet    $(dotnet --version)"
+          dotnet --list-sdks
+          echo "uv        $(uv --version)"
+          ( cd runtime/python/prompty && echo "ruff      $(uv run ruff --version)" )
+          ( cd runtime/typescript && echo "prettier  $(node node_modules/prettier/bin/prettier.cjs --version)" )
+          echo "emitter   $(node -p "require('./schema/package.json').dependencies['@typra/emitter']")"
+
+      - name: Regenerate from the pinned emitter
+        working-directory: schema
+        shell: bash
+        run: |
+          set -o pipefail
+          # The log goes to RUNNER_TEMP, never anywhere under the repo: a log file
+          # inside schema/ would itself show up in `git status --porcelain` below
+          # and fail the very assertion it exists to explain.
+          npm run generate 2>&1 | tee "$RUNNER_TEMP/generate.log"
+
+          # A missing formatter produces a warning and unformatted output, which is
+          # indistinguishable from stale generated code in the diff step below. Fail
+          # here, with the real cause, rather than reporting false staleness.
+          # These strings were verified by running 0.8.7 with the formatters removed.
+          if grep -Eq 'Warning: (prettier|ruff|gofmt|goimports|dotnet format|cargo fmt|Could not find)' "$RUNNER_TEMP/generate.log"; then
+            echo "::error::A formatter was unavailable during generation, so the output is not comparable to the committed tree."
+            echo "This is an environment problem in this job, not stale generated code."
+            echo "Do not 'fix' it by regenerating and committing — that would commit unformatted output."
+            echo ""
+            echo "--- formatter warnings ---"
+            grep -E 'Warning: ' "$RUNNER_TEMP/generate.log" || true
+            exit 1
+          fi
+
+      # Must run before the assertion below: global.json is untracked, and
+      # `git status --porcelain` reports untracked files, so leaving it in place
+      # would fail the very check it exists to make trustworthy. `if: always()`
+      # so a failed generate still cleans up rather than confusing the failure log.
+      - name: Remove the temporary global.json
+        if: always()
+        shell: bash
+        run: rm -f global.json
+
+      - name: Assert the tree is unchanged
+        shell: bash
+        run: |
+          if [ -n "$(git status --porcelain)" ]; then
+            echo "::error::Regenerating changed the tree: the committed generated code does not match the pinned emitter and formatters."
+            echo "Fix: run 'npm run generate' in schema/ and commit the result."
+            echo "(The step above already proved every formatter was present, so this is real drift, not a missing formatter.)"
+            echo ""
+            echo "--- changed files ---"
+            git status --porcelain
+            echo ""
+            echo "--- diff ---"
+            git --no-pager diff --stat
+            echo ""
+            # The patch itself, capped so a whole-tree formatter failure does not
+            # bury the log. --stat alone cannot tell you WHICH tool changed the file;
+            # the actual hunks can (whitespace vs content vs line endings).
+            echo "--- patch (first 300 lines) ---"
+            git --no-pager diff | head -300
+            exit 1
+          fi
+          echo "Generated code matches the pinned emitter exactly."

--- a/runtime/csharp/Prompty.Core/RenderHelpers.cs
+++ b/runtime/csharp/Prompty.Core/RenderHelpers.cs
@@ -71,33 +71,33 @@ public static class RenderHelpers
             switch (value)
             {
                 case IDictionary<string, object?> typed:
-                {
-                    var map = new Dictionary<string, object?>(typed.Count);
-                    foreach (var kvp in typed)
                     {
-                        if (!UnsafeTemplateKeys.Contains(kvp.Key))
-                            map[kvp.Key] = SanitizeValue(kvp.Value, seen);
+                        var map = new Dictionary<string, object?>(typed.Count);
+                        foreach (var kvp in typed)
+                        {
+                            if (!UnsafeTemplateKeys.Contains(kvp.Key))
+                                map[kvp.Key] = SanitizeValue(kvp.Value, seen);
+                        }
+                        return map;
                     }
-                    return map;
-                }
                 case IDictionary raw:
-                {
-                    var map = new Dictionary<string, object?>(raw.Count);
-                    foreach (DictionaryEntry entry in raw)
                     {
-                        var key = entry.Key?.ToString();
-                        if (key is not null && !UnsafeTemplateKeys.Contains(key))
-                            map[key] = SanitizeValue(entry.Value, seen);
+                        var map = new Dictionary<string, object?>(raw.Count);
+                        foreach (DictionaryEntry entry in raw)
+                        {
+                            var key = entry.Key?.ToString();
+                            if (key is not null && !UnsafeTemplateKeys.Contains(key))
+                                map[key] = SanitizeValue(entry.Value, seen);
+                        }
+                        return map;
                     }
-                    return map;
-                }
                 case IEnumerable sequence:
-                {
-                    var list = new List<object?>();
-                    foreach (var item in sequence)
-                        list.Add(SanitizeValue(item, seen));
-                    return list;
-                }
+                    {
+                        var list = new List<object?>();
+                        foreach (var item in sequence)
+                            list.Add(SanitizeValue(item, seen));
+                        return list;
+                    }
                 default:
                     // Non-collection reference types (e.g. Message) carry no
                     // template-reachable string-keyed members, so pass them through.

--- a/runtime/typescript/packages/core/src/model/contracts/events/redacted-field.ts
+++ b/runtime/typescript/packages/core/src/model/contracts/events/redacted-field.ts
@@ -5,11 +5,7 @@
 import { LoadContext, SaveContext } from "../../context";
 
 export type RedactionMode =
-  | "none"
-  | "redacted"
-  | "hashed"
-  | "summary"
-  | "reference";
+  "none" | "redacted" | "hashed" | "summary" | "reference";
 
 export class RedactedField {
   static readonly shorthandProperty: string | undefined = undefined;

--- a/runtime/typescript/packages/core/src/model/contracts/events/session-end-payload.ts
+++ b/runtime/typescript/packages/core/src/model/contracts/events/session-end-payload.ts
@@ -5,10 +5,7 @@
 import { LoadContext, SaveContext } from "../../context";
 
 export type SessionEndStatus =
-  | "success"
-  | "error"
-  | "cancelled"
-  | "interrupted";
+  "success" | "error" | "cancelled" | "interrupted";
 
 export class SessionEndPayload {
   static readonly shorthandProperty: string | undefined = undefined;

--- a/runtime/typescript/packages/core/src/model/contracts/events/session-summary.ts
+++ b/runtime/typescript/packages/core/src/model/contracts/events/session-summary.ts
@@ -6,10 +6,7 @@ import { LoadContext, SaveContext } from "../../context";
 import { TokenUsage } from "../../contracts/models/token-usage";
 
 export type SessionSummaryStatus =
-  | "success"
-  | "error"
-  | "cancelled"
-  | "interrupted";
+  "success" | "error" | "cancelled" | "interrupted";
 
 export class SessionSummary {
   static readonly shorthandProperty: string | undefined = undefined;

--- a/runtime/typescript/packages/core/src/model/contracts/models/model.ts
+++ b/runtime/typescript/packages/core/src/model/contracts/models/model.ts
@@ -7,11 +7,7 @@ import { Connection } from "../../contracts/connectivity/connection";
 import { ModelOptions } from "./model-options";
 
 export type apiType =
-  | "chat"
-  | "embedding"
-  | "image"
-  | "responses"
-  | (string & {});
+  "chat" | "embedding" | "image" | "responses" | (string & {});
 
 export class Model {
   static readonly shorthandProperty: string | undefined = "id";

--- a/runtime/typescript/packages/core/src/model/contracts/pipeline/turn-commit.ts
+++ b/runtime/typescript/packages/core/src/model/contracts/pipeline/turn-commit.ts
@@ -8,10 +8,7 @@ import { Message } from "../../contracts/conversation/message";
 import { ModelReconciliationState } from "./model-reconciliation-state";
 
 export type EngineTurnStatus =
-  | "success"
-  | "failed"
-  | "cancelled"
-  | "reconciliation_required";
+  "success" | "failed" | "cancelled" | "reconciliation_required";
 
 export class TurnCommit {
   static readonly shorthandProperty: string | undefined = undefined;


### PR DESCRIPTION
Adds `.github/workflows/schema-repro-check.yml`, a CI gate that regenerates from the pinned `@typra/emitter` and asserts the committed generated code is exactly what it produces.

## The blind spot this closes

Every runtime workflow in `.github/workflows/` is paths-filtered to `runtime/<lang>/**`. A commit touching only `schema/` — **including one that bumps the emitter pin in `schema/package.json`** — therefore triggers **zero CI**. Nothing verified that the generated code in `runtime/*` still corresponded to the pinned emitter.

That is not hypothetical. Two commits on an earlier branch bumped the pin with no regeneration and no CI run. Both happened to be no-ops, but nothing checked — and the resulting ambiguity cost a long argument that neither side could settle without running the generator.

## What this adds

| | |
|---|---|
| **Triggers** | `pull_request` on `schema/**`, the workflow itself, the manifests that pin formatter versions, and `runtime/csharp/Prompty.Core*`; plus `workflow_call` and `workflow_dispatch` |
| **Runs** | `npm ci` then `npm run generate` in `schema/`, with every formatter the emitter shells out to installed |
| **Asserts** | `git status --porcelain` is empty; on failure prints the changed files, `git diff --stat`, and the first 300 lines of the patch |

## The formatter subtlety — why the job fails on the warning, not just the diff

The emitter shells out to external formatters, and **each one degrades to a warning when absent rather than failing**. A missing formatter produces unformatted output that is *indistinguishable in the diff from stale generated code*.

Measured, by hiding prettier, uv, dotnet and Go from `PATH`:

| Scenario | Result |
|---|---|
| All formatters present, genuine drift | **5 files**, +5 / −22 |
| Formatters missing | **1121 files**, +47434 |

That two-orders-of-magnitude gap is what makes the warning grep defensible rather than superstitious. The job tees the generate output to a log, greps it for formatter-missing warnings, and **fails on the warning itself before the diff assertion**, with a message saying plainly that this is a broken job environment and *not* stale generated code.

The log goes to `$RUNNER_TEMP`. A log file under `schema/` would itself appear in `git status --porcelain` and fail the very assertion it exists to explain.

## The gate found real drift on its first run — fixed in the first commit

`chore(typescript): regenerate model with prettier 3.9.6` — 5 model files, whitespace only.

**The cause is not the emitter.** #465 regenerated `runtime/typescript/package-lock.json` for the npm audit remediation, moving prettier **3.8.3 → 3.9.6**, and 3.9.6 collapses a short union onto one line where 3.8.3 wrapped it. Measured directly: the committed files are prettier-3.8.3-clean (`--check` → *"All matched files use Prettier code style!"*) and 3.9.6-dirty.

Nothing could see it — `packages/core`'s `lint` is `tsc --noEmit`, not a format check.

## Trigger paths go past `schema/**` — deliberately

`schema/**` alone would have let the prettier bump through clean and then blamed the next unrelated schema PR. Misattributing a signal to whatever commit happened to trip it is precisely the failure this gate exists to prevent, so the paths also cover every manifest that pins a formatter version:

- `runtime/typescript/package.json` and `package-lock.json` — prettier / eslint
- `runtime/python/prompty/pyproject.toml` and `uv.lock` — ruff
- `runtime/go/prompty/go.mod` — gofmt is toolchain-tied
- `.editorconfig` — consumed by `dotnet format`
- `schema/package-lock.json` (already inside `schema/**`) — the emitter pin itself, and therefore the highest-value trigger of all

## rustfmt's failure mode — verified specifically

rustfmt is the one formatter that **cannot** cause silent false staleness. Since `10aee1dd` folded `format:rust` into the generate script, it is invoked by npm rather than by the emitter, so a missing `cargo fmt` **exits 1 loudly** instead of degrading to a warning. (The emitter's own Rust driver looks for `runtime/rust/prompty/src/Cargo.toml`, which does not exist, and is a silent no-op — but it formats nothing, so it cannot dirty the tree either.)

## Toolchain pinning

Path triggers can only catch formatter versions pinned by **files in the repo**. A floating `@stable` rustfmt or `9.0.x` SDK drifts with no repo change at all, so no path filter can catch it — it would simply redden an unrelated contributor's PR. Every toolchain is therefore pinned to an exact version, with a comment saying why, and a **Record toolchain versions** step prints them all so *"did the generated code change, or did a formatter?"* is answerable from the log rather than by bisecting.

That step immediately proved the .NET pin was a no-op. **`setup-dotnet`'s `dotnet-version` installs an SDK but does not select one:** `dotnet --version` reported **10.0.302** despite `dotnet-version: 9.0.317`, because the image carries eleven SDKs and absent a `global.json` the highest wins. The job now writes an ephemeral repo-root `global.json` before regenerating and removes it in an `if: always()` step **before** the assertion — mandatory, since an untracked file would fail the `git status --porcelain` check itself.

## Consequence for dependabot — expected, not a bug

Now that the lockfiles are trigger paths, a dependabot bump that moves a formatter **will** fail this gate and require a regeneration commit on that PR. That is correct behavior, but it will surprise someone at 2am, so: **the fix is always to run `npm run generate` in `schema/` and commit the result.**

If instead the job fails at the *formatter warning* step, do **not** regenerate — that means a formatter was missing in the job, and regenerating would commit unformatted output.

## The gate found a second real drift — from a PR that was not this one

While this PR was open, `main` advanced to `76a8ab1e` (#472, *sanitize renderer inputs against template injection*), which added hand-written C# to `Prompty.Core/RenderHelpers.cs` that `dotnet format` rewrites (21 lines of switch-case block indentation). Because `pull_request` builds the **merge commit**, this gate began failing on a file this PR never authored. That is the gate working, not flaking — the merged tree genuinely was not reproducible. The third commit applies that formatting; it is whitespace only (`git diff -w` against the merge base is empty) and the resulting blob is byte-identical under SDK 9.0.317, 10.0.111 and 10.0.302.

### Why `runtime/csharp/Prompty.Core*` are trigger paths

C# is the **only** language here where hand-written code is an input to reproducibility:

| Language | What the emitter driver formats | Hand-written code affected? |
|---|---|---|
| **C#** | `dotnet format <csproj>` — the **whole project** | **Yes** |
| Python | `ruff check --fix` / `ruff format` on the emitted dirs | No |
| Go | `gofmt -w` on the emitted dirs | No |
| TypeScript | prettier / eslint on the emitted dirs | No |

So a non-format-clean C# PR merges quietly and then reddens the *next* unrelated schema PR — the misattribution this gate exists to prevent, rebuilt inside the gate. These paths make that failure land on the PR that causes it, at the cost of running this ~4-minute job on C# PRs touching those two projects.

### A gap this exposes — CORRECTED after merge

> **Correction.** The original text here said `prompty-csharp-check.yml` "builds and tests but never runs `dotnet format --verify-no-changes`, which is why #472 could merge non-clean." **That was wrong, and I did not verify it before writing it.** The same wrong claim is in the squashed commit message on `main` (`f242abf7`), which cannot be amended. This section is the correction.

Measured after merge:

| Claim | Reality |
|---|---|
| `prompty-csharp-check.yml` never runs `dotnet format --verify-no-changes` | **It does** — added in `5609e39f` (2026-04-08), four months before #472 |
| ...which is why #472 merged non-clean | **It ran, and it failed.** Step `dotnet format check` = FAILURE on `macOS-latest` in run `32083633956`; the `ubuntu-latest` and `windows-latest` legs were CANCELLED by fail-fast |

So the C# check works and caught this exact drift on the PR that caused it. The real reason #472 landed anyway is broader:

**`main` has no required status checks.**

```
$ gh api repos/microsoft/prompty/branches/main --jq '{protected, required:(.protection.required_status_checks.contexts//[])}'
{"protected":true,"required":[]}
```

Branch protection requires one approving review and enforces no checks at all. Every check in this repo is advisory — **including the gate this PR adds.** `schema-repro-check` detects drift; nothing prevents merging over it.

That is tracked in #473, along with the other follow-ups this PR deliberately did not fold in:

- **#473** — no required status checks on `main` (this finding)
- **#474** — pin the Rust toolchain and .NET SDK in-repo, so local and CI agree by construction
- **#475** — hand-written TypeScript has no format check (`packages/core` lint is only `tsc --noEmit`)
- **#476** — narrow the `runtime/csharp/Prompty.Core*` triggers once #473 lands
- **#477** — scheduled canary run of this gate against `main`

## Verification performed before opening this PR

1. `npm ci && npm run generate` in `schema/` on current `main`.
2. Confirmed the resulting tree state and diagnosed the only diff (the prettier drift above) rather than committing through it.
3. Ran `npm run generate` a **second** time and confirmed it is idempotent — byte-identical output.
4. Confirmed all five formatters were present locally, so a clean tree is not itself a false negative.

**Not verified locally:** the job as it runs on `ubuntu-latest` — local reproduction was on Windows, and `dotnet format` / `gofmt` were exercised via locally installed toolchains rather than via `setup-dotnet` / `setup-go`.

## Known limitations — stated plainly so they are not rediscovered

**The failure paths have never executed on a runner.** Every CI run of this job has ended green or failed at the *diff assertion* (which is how both drifts above were caught). The **formatter-warning branch has never fired in CI.** It was proven locally — all five warning strings reproduced, 1121 files vs 5 — but local Windows reproduction is evidence, not proof. Both branches are simple `grep` / `git status` conditionals and the success path demonstrably works, so a deliberately-broken commit to exercise the red path was judged not worth the cost. **The next person to touch this should know the red path is untested in CI.**

**Workflow pins bind CI, not developers.** Pinning here stops CI-side drift, but a developer running `cargo fmt` on rustup stable, or `dotnet format` on whichever SDK they have, can still produce output this job rejects. The durable instrument is a root `rust-toolchain.toml` plus a committed `global.json` — rustup, `dtolnay/rust-toolchain` and the .NET CLI all honour them, so local and CI agree by construction. That changes the toolchain for every Rust and C# developer here, so it belongs in **its own PR with its own review**.

**Deliberately ubuntu-only.** Reproducibility needs one canonical platform; adding runners would multiply formatter-version surface for no gain.

**`uv run ruff` is not relied on bare.** `ruff` lives in `[project.optional-dependencies].dev`, not a `[dependency-groups]`, so `uv run` alone would not necessarily resolve it. The job mirrors the local recipe (`uv venv` + `uv pip install -e ".[dev]"`).

**`UV_FROZEN: '1'`** is set at job level so a `uv` re-lock becomes an explicit lockfile error rather than misattributed staleness.

## Separate finding, deliberately not fixed here

`runtime/typescript/packages/core`'s `lint` script is `tsc --noEmit` — hand-written TypeScript has **no formatting check at all**. This gate covers generated TS implicitly, but not the rest. That is a real gap and belongs in its own PR.