### PR TITLE
fix(csharp): sanitize Jinja2 renderer inputs against template injection (#432)

### DIFF
--- a/runtime/csharp/Prompty.Core.Tests/RendererTests.cs
+++ b/runtime/csharp/Prompty.Core.Tests/RendererTests.cs
@@ -201,8 +201,126 @@ public class Jinja2RendererTests
 }
 
 // -----------------------------------------------------------------------
-// MustacheRenderer Tests
+// Input Sanitization Tests (issue #432 — sibling of GHSA-w28w-gp39-m4p6)
 // -----------------------------------------------------------------------
+
+public class RenderInputSanitizationTests
+{
+    private readonly Jinja2Renderer _renderer = new();
+
+    [Theory]
+    [InlineData("__proto__")]
+    [InlineData("constructor")]
+    [InlineData("prototype")]
+    public void SanitizeInputs_StripsUnsafeTopLevelKeys(string unsafeKey)
+    {
+        var inputs = new Dictionary<string, object?>
+        {
+            [unsafeKey] = "attack",
+            ["name"] = "Jane",
+        };
+
+        var result = RenderHelpers.SanitizeInputs(inputs);
+
+        Assert.False(result.ContainsKey(unsafeKey));
+        Assert.Equal("Jane", result["name"]);
+    }
+
+    [Fact]
+    public void SanitizeInputs_StripsUnsafeKeysInNestedDictionaries()
+    {
+        var inputs = new Dictionary<string, object?>
+        {
+            ["profile"] = new Dictionary<string, object?>
+            {
+                ["constructor"] = "attack",
+                ["displayName"] = "Jane",
+            },
+        };
+
+        var result = RenderHelpers.SanitizeInputs(inputs);
+
+        var profile = Assert.IsType<Dictionary<string, object?>>(result["profile"]);
+        Assert.False(profile.ContainsKey("constructor"));
+        Assert.Equal("Jane", profile["displayName"]);
+    }
+
+    [Fact]
+    public void SanitizeInputs_StripsUnsafeKeysInsideCollections()
+    {
+        var inputs = new Dictionary<string, object?>
+        {
+            ["items"] = new List<object?>
+            {
+                new Dictionary<string, object?> { ["__proto__"] = "attack", ["value"] = 1 },
+            },
+        };
+
+        var result = RenderHelpers.SanitizeInputs(inputs);
+
+        var list = Assert.IsType<List<object?>>(result["items"]);
+        var entry = Assert.IsType<Dictionary<string, object?>>(list[0]);
+        Assert.False(entry.ContainsKey("__proto__"));
+        Assert.Equal(1, entry["value"]);
+    }
+
+    [Fact]
+    public void SanitizeInputs_DoesNotMutateOriginal()
+    {
+        var inputs = new Dictionary<string, object?> { ["__proto__"] = "attack", ["name"] = "Jane" };
+
+        RenderHelpers.SanitizeInputs(inputs);
+
+        Assert.True(inputs.ContainsKey("__proto__"));
+    }
+
+    [Fact]
+    public void SanitizeInputs_HandlesCyclicReferences()
+    {
+        var cyclic = new Dictionary<string, object?> { ["name"] = "Jane" };
+        cyclic["self"] = cyclic;
+        var inputs = new Dictionary<string, object?> { ["node"] = cyclic };
+
+        var result = RenderHelpers.SanitizeInputs(inputs);
+
+        var node = Assert.IsType<Dictionary<string, object?>>(result["node"]);
+        Assert.Equal("Jane", node["name"]);
+        Assert.Null(node["self"]); // cycle broken, not infinite recursion
+    }
+
+    [Fact]
+    public async Task Render_DoesNotExposeConstructorMember()
+    {
+        var agent = CreateAgentBase();
+        // Without sanitization, {{ obj.constructor }} could reach the prototype chain.
+        var result = await _renderer.RenderAsync(
+            agent,
+            "{{ obj.constructor }}",
+            new() { ["obj"] = new Dictionary<string, object?> { ["constructor"] = "leaked" } });
+
+        Assert.DoesNotContain("leaked", result);
+    }
+
+    [Fact]
+    public async Task Render_NormalInputsStillWork()
+    {
+        var agent = CreateAgentBase();
+        var result = await _renderer.RenderAsync(agent, "Hello {{ name }}!", new() { ["name"] = "Jane" });
+        Assert.Equal("Hello Jane!", result);
+    }
+
+    private static Agent CreateAgentBase()
+    {
+        var data = new Dictionary<string, object?>
+        {
+            ["kind"] = "prompt",
+            ["name"] = "test",
+            ["instructions"] = "",
+            ["model"] = "gpt-4",
+        };
+        return Agent.Load(data, new LoadContext());
+    }
+}
 
 public class MustacheRendererTests
 {

--- a/runtime/csharp/Prompty.Core/Jinja2Renderer.cs
+++ b/runtime/csharp/Prompty.Core/Jinja2Renderer.cs
@@ -18,12 +18,17 @@ public class Jinja2Renderer : IRenderer
         var (renderInputs, nonces) = RenderHelpers.PrepareRenderInputs(agent, inputs);
         LastNonces = nonces;
 
+        // Strip prototype-chain escape hatches (__proto__, constructor, prototype)
+        // before rendering — defense-in-depth against template injection, the C#
+        // sibling of GHSA-w28w-gp39-m4p6 (see issue #432).
+        var safeInputs = RenderHelpers.SanitizeInputs(renderInputs);
+
         // Jinja2.NET: create template and render with context
         var jinja = new Jinja2.NET.Template(template);
 
         // Convert to IDictionary<string, object> for Jinja2.NET (no nulls)
         var context = new Dictionary<string, object>();
-        foreach (var kvp in renderInputs)
+        foreach (var kvp in safeInputs)
         {
             if (kvp.Value is not null)
                 context[kvp.Key] = kvp.Value;

--- a/runtime/csharp/Prompty.Core/RenderHelpers.cs
+++ b/runtime/csharp/Prompty.Core/RenderHelpers.cs
@@ -1,5 +1,6 @@
 // Copyright (c) Microsoft. All rights reserved.
 
+using System.Collections;
 using System.Security.Cryptography;
 
 namespace Prompty.Core;
@@ -14,6 +15,100 @@ public static class RenderHelpers
     /// Format: __PROMPTY_THREAD_{hex8}_{name}__
     /// </summary>
     public const string ThreadNoncePrefix = "__PROMPTY_THREAD_";
+
+    /// <summary>
+    /// Property names that must never be reachable through template member access.
+    /// These are the classic prototype-pollution / prototype-chain escape hatches
+    /// (mirrors the TypeScript renderer's UNSAFE_PROPERTIES set).
+    /// </summary>
+    private static readonly HashSet<string> UnsafeTemplateKeys = new(StringComparer.Ordinal)
+    {
+        "__proto__",
+        "constructor",
+        "prototype",
+    };
+
+    /// <summary>
+    /// Recursively strips unsafe keys from rendering inputs before they reach the
+    /// template engine. This is the C# equivalent of the TypeScript
+    /// <c>sanitizeInputs</c> defense added for GHSA-w28w-gp39-m4p6 (server-side
+    /// template injection in the renderer) and the sibling C# finding (issue #432).
+    ///
+    /// Even though Jinja2.NET blocks function calls, unsanitized inputs can still
+    /// expose prototype-chain / constructor members via attribute access
+    /// (<c>{{ obj.constructor }}</c>). Removing those keys keeps the template
+    /// context to plain data only. A fresh copy is always returned; the caller's
+    /// dictionary is never mutated.
+    /// </summary>
+    public static Dictionary<string, object?> SanitizeInputs(Dictionary<string, object?> inputs)
+    {
+        var result = new Dictionary<string, object?>(inputs.Count);
+        foreach (var kvp in inputs)
+        {
+            if (UnsafeTemplateKeys.Contains(kvp.Key))
+                continue;
+            result[kvp.Key] = SanitizeValue(kvp.Value, new HashSet<object>(ReferenceEqualityComparer.Instance));
+        }
+        return result;
+    }
+
+    private static object? SanitizeValue(object? value, HashSet<object> seen)
+    {
+        switch (value)
+        {
+            case null:
+            case string:
+            case ValueType:
+                return value;
+        }
+
+        // Guard against cyclic references in nested structures.
+        if (!seen.Add(value!))
+            return null;
+
+        try
+        {
+            switch (value)
+            {
+                case IDictionary<string, object?> typed:
+                {
+                    var map = new Dictionary<string, object?>(typed.Count);
+                    foreach (var kvp in typed)
+                    {
+                        if (!UnsafeTemplateKeys.Contains(kvp.Key))
+                            map[kvp.Key] = SanitizeValue(kvp.Value, seen);
+                    }
+                    return map;
+                }
+                case IDictionary raw:
+                {
+                    var map = new Dictionary<string, object?>(raw.Count);
+                    foreach (DictionaryEntry entry in raw)
+                    {
+                        var key = entry.Key?.ToString();
+                        if (key is not null && !UnsafeTemplateKeys.Contains(key))
+                            map[key] = SanitizeValue(entry.Value, seen);
+                    }
+                    return map;
+                }
+                case IEnumerable sequence:
+                {
+                    var list = new List<object?>();
+                    foreach (var item in sequence)
+                        list.Add(SanitizeValue(item, seen));
+                    return list;
+                }
+                default:
+                    // Non-collection reference types (e.g. Message) carry no
+                    // template-reachable string-keyed members, so pass them through.
+                    return value;
+            }
+        }
+        finally
+        {
+            seen.Remove(value!);
+        }
+    }
 
     /// <summary>
     /// Prepares inputs for rendering by replacing rich-kind values with nonce markers.


### PR DESCRIPTION
Closes #432.

## Summary
Adds input sanitization to the C# `Jinja2Renderer` — the sibling finding of **GHSA-w28w-gp39-m4p6** (SSTI in the TypeScript renderer). The C# renderer previously passed raw inputs into the Jinja2.NET template context with none of the `sanitizeInputs` protection deemed necessary for the TypeScript and Python runtimes.

## Fix
- New `RenderHelpers.SanitizeInputs` recursively strips the prototype-chain escape hatches (`__proto__`, `constructor`, `prototype`) from input dictionaries, nested dictionaries, and collections. Includes cycle protection and never mutates the caller's inputs (mirrors the TS `UNSAFE_PROPERTIES` / `sanitizeInputs` defense).
- `Jinja2Renderer.RenderAsync` now sanitizes `renderInputs` before building the template context.

While Jinja2.NET already throws on template function calls (so direct RCE isn't reachable), attribute access like `{{ obj.constructor }}` was unsanitized — this closes that information-disclosure / defense-in-depth gap.

## Tests
12 new regression tests in `RendererTests.cs` (top-level/nested/collection key stripping, non-mutation, cyclic references, `constructor` no longer reachable from templates, normal inputs still render). Full `Prompty.Core.Tests` suite: **1260 passing**.

## References
- Existing advisory: GHSA-w28w-gp39-m4p6
- TypeScript fix parity: `runtime/typescript/packages/core/src/renderers/nunjucks.ts`