### PR TITLE
feat(deps): adopt @typra/emitter 0.9.0 + @typespec 1.15

### DIFF
--- a/schema/package-lock.json
+++ b/schema/package-lock.json
@@ -6,10 +6,10 @@
     "": {
       "name": "prompty-schema",
       "dependencies": {
-        "@typespec/compiler": "^1.10.0",
-        "@typespec/http": "^1.10.0",
-        "@typespec/json-schema": "^1.10.0",
-        "@typra/emitter": "^0.8.7"
+        "@typespec/compiler": "^1.15.0",
+        "@typespec/http": "^1.15.0",
+        "@typespec/json-schema": "^1.15.0",
+        "@typra/emitter": "^0.9.0"
       }
     },
     "node_modules/@babel/code-frame": {
@@ -369,53 +369,6 @@
         "node": ">=18.0.0"
       }
     },
-    "node_modules/@nodelib/fs.scandir": {
-      "version": "2.1.5",
-      "resolved": "https://registry.npmjs.org/@nodelib/fs.scandir/-/fs.scandir-2.1.5.tgz",
-      "integrity": "sha512-vq24Bq3ym5HEQm2NKCr3yXDwjc7vTsEThRDnkp2DK9p1uqLR+DHurm/NOTo0KG7HYHU7eppKZj3MyqYuMBf62g==",
-      "license": "MIT",
-      "dependencies": {
-        "@nodelib/fs.stat": "2.0.5",
-        "run-parallel": "^1.1.9"
-      },
-      "engines": {
-        "node": ">= 8"
-      }
-    },
-    "node_modules/@nodelib/fs.stat": {
-      "version": "2.0.5",
-      "resolved": "https://registry.npmjs.org/@nodelib/fs.stat/-/fs.stat-2.0.5.tgz",
-      "integrity": "sha512-RkhPPp2zrqDAQA/2jNhnztcPAlv64XdhIp7a7454A5ovI7Bukxgt7MX7udwAu3zg1DcpPU0rz3VV1SeaqvY4+A==",
-      "license": "MIT",
-      "engines": {
-        "node": ">= 8"
-      }
-    },
-    "node_modules/@nodelib/fs.walk": {
-      "version": "1.2.8",
-      "resolved": "https://registry.npmjs.org/@nodelib/fs.walk/-/fs.walk-1.2.8.tgz",
-      "integrity": "sha512-oGB+UxlgWcgQkgwo8GcEGwemoTFt3FIO9ababBmaGwXIoBKZ+GTy0pP185beGg7Llih/NSHSV2XAs1lnznocSg==",
-      "license": "MIT",
-      "dependencies": {
-        "@nodelib/fs.scandir": "2.1.5",
-        "fastq": "^1.6.0"
-      },
-      "engines": {
-        "node": ">= 8"
-      }
-    },
-    "node_modules/@sindresorhus/merge-streams": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/@sindresorhus/merge-streams/-/merge-streams-4.0.0.tgz",
-      "integrity": "sha512-tlqY9xq5ukxTUZBmoOp+m61cqwQD5pHJtFY3Mn8CA8ps6yghLH/Hw8UPdqg4OLmFW3IFlcXnQNmo/dh8HzXYIQ==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=18"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
     "node_modules/@typespec/asset-emitter": {
       "version": "0.79.1",
       "license": "MIT",
@@ -427,50 +380,49 @@
       }
     },
     "node_modules/@typespec/compiler": {
-      "version": "1.10.0",
-      "resolved": "https://registry.npmjs.org/@typespec/compiler/-/compiler-1.10.0.tgz",
-      "integrity": "sha512-R6BATDkughntPpaxeESJF+wxma5PEjgmnnKvH0/ByqUH8VyhIckQWE9kkP0Uc/EJ0o0VYhe8qCwWQvV70k5lTw==",
+      "version": "1.15.0",
+      "resolved": "https://registry.npmjs.org/@typespec/compiler/-/compiler-1.15.0.tgz",
+      "integrity": "sha512-NbCIRAIzyozchlSaGPVuyV43bC+y+OpXYCuT+8M8kt35Ln9zWzLFcIt7irofQ5QUXBZrHsBFpI5fTOFdCGeWCA==",
       "license": "MIT",
       "peer": true,
       "dependencies": {
-        "@babel/code-frame": "~7.29.0",
-        "@inquirer/prompts": "^8.0.1",
-        "ajv": "~8.18.0",
-        "change-case": "~5.4.4",
+        "@babel/code-frame": "^7.29.0",
+        "@inquirer/prompts": "^8.4.1",
+        "ajv": "^8.18.0",
+        "change-case": "^5.4.4",
         "env-paths": "^4.0.0",
-        "globby": "~16.1.0",
         "is-unicode-supported": "^2.1.0",
-        "mustache": "~4.2.0",
-        "picocolors": "~1.1.1",
-        "prettier": "~3.8.0",
-        "semver": "^7.7.1",
-        "tar": "^7.5.2",
-        "temporal-polyfill": "^0.3.0",
-        "vscode-languageserver": "~9.0.1",
-        "vscode-languageserver-textdocument": "~1.0.12",
-        "yaml": "~2.8.2",
-        "yargs": "~18.0.0"
+        "mustache": "^4.2.0",
+        "picocolors": "^1.1.1",
+        "prettier": "^3.9.5",
+        "semver": "^7.7.4",
+        "tar": "^7.5.21",
+        "temporal-polyfill": "^1.0.1",
+        "vscode-languageserver": "^10.0.0",
+        "vscode-languageserver-textdocument": "^1.0.12",
+        "yaml": "^2.8.3",
+        "yargs": "^18.0.0"
       },
       "bin": {
         "tsp": "cmd/tsp.js",
         "tsp-server": "cmd/tsp-server.js"
       },
       "engines": {
-        "node": ">=20.0.0"
+        "node": ">=22.0.0"
       }
     },
     "node_modules/@typespec/http": {
-      "version": "1.10.0",
-      "resolved": "https://registry.npmjs.org/@typespec/http/-/http-1.10.0.tgz",
-      "integrity": "sha512-/fj55fmUj4m/FmNdfH0V52menVrmS2r5Xj9d1H+pnjQbxvvaxS906RSRcoF8kbg3PvlibP/Py5u82TAk53AyqA==",
+      "version": "1.15.0",
+      "resolved": "https://registry.npmjs.org/@typespec/http/-/http-1.15.0.tgz",
+      "integrity": "sha512-LNyzYHyX3C0xyQQ262jhvIaVzTn7DqiDB2gz45w1m6ngJH9ArGU8XjO3o7PaZkl/nuB5MTpImnsXpHIV1rbi4Q==",
       "license": "MIT",
       "peer": true,
       "engines": {
-        "node": ">=20.0.0"
+        "node": ">=22.0.0"
       },
       "peerDependencies": {
-        "@typespec/compiler": "^1.10.0",
-        "@typespec/streams": "^0.80.0"
+        "@typespec/compiler": "^1.15.0",
+        "@typespec/streams": "^0.85.0"
       },
       "peerDependenciesMeta": {
         "@typespec/streams": {
@@ -479,28 +431,29 @@
       }
     },
     "node_modules/@typespec/json-schema": {
-      "version": "1.10.0",
-      "resolved": "https://registry.npmjs.org/@typespec/json-schema/-/json-schema-1.10.0.tgz",
-      "integrity": "sha512-FZTJvZoIqMbe/4qi17e8q3KF/2VDSyXiiF8QYwH4lar5dtEDGgwrw9ShLeLNiEZh8Ph3GjrQQV5qdpheDFJJvw==",
+      "version": "1.15.0",
+      "resolved": "https://registry.npmjs.org/@typespec/json-schema/-/json-schema-1.15.0.tgz",
+      "integrity": "sha512-sq27AxnzVRX5mrPlncsqQLi2aE34CLDALaqbY2HmnMiYmS70wY1zJH3I4hWT4AUxiZYokln9sf0FZ4ukT6ZJ+Q==",
       "license": "MIT",
       "peer": true,
       "dependencies": {
         "@typespec/asset-emitter": "^0.79.1",
-        "yaml": "~2.8.2"
+        "yaml": "^2.8.3"
       },
       "engines": {
-        "node": ">=20.0.0"
+        "node": ">=22.0.0"
       },
       "peerDependencies": {
-        "@typespec/compiler": "^1.10.0"
+        "@typespec/compiler": "^1.15.0"
       }
     },
     "node_modules/@typra/emitter": {
-      "version": "0.8.7",
-      "resolved": "https://registry.npmjs.org/@typra/emitter/-/emitter-0.8.7.tgz",
-      "integrity": "sha512-dSWdpSQGwywT02vfOLiY4PfT/794pw8PJZkX2kyMVUKM++XWjm3941ey6QPMJQtYFxJfK3xj3q3GtwRXCXjFhA==",
+      "version": "0.9.0",
+      "resolved": "https://registry.npmjs.org/@typra/emitter/-/emitter-0.9.0.tgz",
+      "integrity": "sha512-wEhZm2BXaEfPBiZD9eWkE6Z1ExQxrtBC9ZLv28NsX1bVMuh90wX5FFQNlNAxmL2EN5aOZV8C2oWGty6yfo0JUQ==",
       "license": "MIT",
       "dependencies": {
+        "semver": "^7.7.0",
         "xml-formatter": "^3.6.7",
         "yaml": "^2.8.1"
       },
@@ -510,9 +463,9 @@
         "typra-verify": "dist/src/verify-cli.js"
       },
       "peerDependencies": {
-        "@typespec/compiler": "1.10.0",
-        "@typespec/http": "1.10.0",
-        "@typespec/json-schema": "1.10.0"
+        "@typespec/compiler": ">=1.10.0 <2.0.0",
+        "@typespec/http": ">=1.10.0 <2.0.0",
+        "@typespec/json-schema": ">=1.10.0 <2.0.0"
       }
     },
     "node_modules/ajv": {
@@ -547,18 +500,6 @@
       },
       "funding": {
         "url": "https://github.com/chalk/ansi-styles?sponsor=1"
-      }
-    },
-    "node_modules/braces": {
-      "version": "3.0.3",
-      "resolved": "https://registry.npmjs.org/braces/-/braces-3.0.3.tgz",
-      "integrity": "sha512-yQbXgO/OSZVD2IsiLlro+7Hf6Q18EJrKSEsdoMzKePKXct3gvD8oLcOQdIzGupr5Fj+EDe8gO/lxc1BzfMpxvA==",
-      "license": "MIT",
-      "dependencies": {
-        "fill-range": "^7.1.1"
-      },
-      "engines": {
-        "node": ">=8"
       }
     },
     "node_modules/change-case": {
@@ -627,22 +568,6 @@
       "version": "3.1.3",
       "license": "MIT"
     },
-    "node_modules/fast-glob": {
-      "version": "3.3.3",
-      "resolved": "https://registry.npmjs.org/fast-glob/-/fast-glob-3.3.3.tgz",
-      "integrity": "sha512-7MptL8U0cqcFdzIzwOTHoilX9x5BrNqye7Z/LuC7kCMRio1EMSyqRK3BEAUD7sXRq4iT4AzTVuZdhgQ2TCvYLg==",
-      "license": "MIT",
-      "dependencies": {
-        "@nodelib/fs.stat": "^2.0.2",
-        "@nodelib/fs.walk": "^1.2.3",
-        "glob-parent": "^5.1.2",
-        "merge2": "^1.3.0",
-        "micromatch": "^4.0.8"
-      },
-      "engines": {
-        "node": ">=8.6.0"
-      }
-    },
     "node_modules/fast-string-truncated-width": {
       "version": "3.0.3",
       "resolved": "https://registry.npmjs.org/fast-string-truncated-width/-/fast-string-truncated-width-3.0.3.tgz",
@@ -683,27 +608,6 @@
         "fast-string-width": "^3.0.2"
       }
     },
-    "node_modules/fastq": {
-      "version": "1.20.1",
-      "resolved": "https://registry.npmjs.org/fastq/-/fastq-1.20.1.tgz",
-      "integrity": "sha512-GGToxJ/w1x32s/D2EKND7kTil4n8OVk/9mycTc4VDza13lOvpUZTGX3mFSCtV9ksdGBVzvsyAVLM6mHFThxXxw==",
-      "license": "ISC",
-      "dependencies": {
-        "reusify": "^1.0.4"
-      }
-    },
-    "node_modules/fill-range": {
-      "version": "7.1.1",
-      "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-7.1.1.tgz",
-      "integrity": "sha512-YsGpe3WHLK8ZYi4tWDg2Jy3ebRz2rXowDxnld4bkQB00cc/1Zw9AWnC0i9ztDJitivtQvaI9KaLyKrc+hBW0yg==",
-      "license": "MIT",
-      "dependencies": {
-        "to-regex-range": "^5.0.1"
-      },
-      "engines": {
-        "node": ">=8"
-      }
-    },
     "node_modules/get-caller-file": {
       "version": "2.0.5",
       "license": "ISC",
@@ -716,38 +620,6 @@
       "license": "MIT",
       "engines": {
         "node": ">=18"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/glob-parent": {
-      "version": "5.1.2",
-      "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-5.1.2.tgz",
-      "integrity": "sha512-AOIgSQCepiJYwP3ARnGx+5VnTu2HBYdzbGP45eLw1vr3zB3vZLeyed1sC9hnbcOc9/SrMyM5RPQrkGz4aS9Zow==",
-      "license": "ISC",
-      "dependencies": {
-        "is-glob": "^4.0.1"
-      },
-      "engines": {
-        "node": ">= 6"
-      }
-    },
-    "node_modules/globby": {
-      "version": "16.1.1",
-      "resolved": "https://registry.npmjs.org/globby/-/globby-16.1.1.tgz",
-      "integrity": "sha512-dW7vl+yiAJSp6aCekaVnVJxurRv7DCOLyXqEG3RYMYUg7AuJ2jCqPkZTA8ooqC2vtnkaMcV5WfFBMuEnTu1OQg==",
-      "license": "MIT",
-      "dependencies": {
-        "@sindresorhus/merge-streams": "^4.0.0",
-        "fast-glob": "^3.3.3",
-        "ignore": "^7.0.5",
-        "is-path-inside": "^4.0.0",
-        "slash": "^5.1.0",
-        "unicorn-magic": "^0.4.0"
-      },
-      "engines": {
-        "node": ">=20"
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
@@ -767,57 +639,6 @@
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/express"
-      }
-    },
-    "node_modules/ignore": {
-      "version": "7.0.5",
-      "resolved": "https://registry.npmjs.org/ignore/-/ignore-7.0.5.tgz",
-      "integrity": "sha512-Hs59xBNfUIunMFgWAbGX5cq6893IbWg4KnrjbYwX3tx0ztorVgTDA6B2sxf8ejHJ4wz8BqGUMYlnzNBer5NvGg==",
-      "license": "MIT",
-      "engines": {
-        "node": ">= 4"
-      }
-    },
-    "node_modules/is-extglob": {
-      "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-2.1.1.tgz",
-      "integrity": "sha512-SbKbANkN603Vi4jEZv49LeVJMn4yGwsbzZworEoyEiutsN3nJYdbO36zfhGJ6QEDpOZIFkDtnq5JRxmvl3jsoQ==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
-    "node_modules/is-glob": {
-      "version": "4.0.3",
-      "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-4.0.3.tgz",
-      "integrity": "sha512-xelSayHH36ZgE7ZWhli7pW34hNbNl8Ojv5KVmkJD4hBdD3th8Tfk9vYasLM+mXWOZhFkgZfxhLSnrwRr4elSSg==",
-      "license": "MIT",
-      "dependencies": {
-        "is-extglob": "^2.1.1"
-      },
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
-    "node_modules/is-number": {
-      "version": "7.0.0",
-      "resolved": "https://registry.npmjs.org/is-number/-/is-number-7.0.0.tgz",
-      "integrity": "sha512-41Cifkg6e8TylSpdtTpeLVMqvSBEVzTttHvERD741+pnZ8ANv0004MRL43QKPDlK9cGvNp6NZWZUBlbGXYxxng==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=0.12.0"
-      }
-    },
-    "node_modules/is-path-inside": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/is-path-inside/-/is-path-inside-4.0.0.tgz",
-      "integrity": "sha512-lJJV/5dYS+RcL8uQdBDW9c9uWFLLBNRyFhnAKXw5tVqLlKZ4RMGZKv+YQ/IA3OhD+RpbJa1LLFM1FQPGyIXvOA==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=12"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/is-safe-filename": {
@@ -847,28 +668,6 @@
     "node_modules/json-schema-traverse": {
       "version": "1.0.0",
       "license": "MIT"
-    },
-    "node_modules/merge2": {
-      "version": "1.4.1",
-      "resolved": "https://registry.npmjs.org/merge2/-/merge2-1.4.1.tgz",
-      "integrity": "sha512-8q7VEgMJW4J8tcfVPy8g09NcQwZdbwFEqhe/WZkoIzjn/3TGDwtOCYtXGxA3O8tPzpczCCDgv+P2P5y00ZJOOg==",
-      "license": "MIT",
-      "engines": {
-        "node": ">= 8"
-      }
-    },
-    "node_modules/micromatch": {
-      "version": "4.0.8",
-      "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-4.0.8.tgz",
-      "integrity": "sha512-PXwfBhYu0hBCPw8Dn0E+WDYb7af3dSLVWKi3HGv84IdF4TyFoC0ysxFd0Goxw7nSv4T/PzEJQxsYsEiFCKo2BA==",
-      "license": "MIT",
-      "dependencies": {
-        "braces": "^3.0.3",
-        "picomatch": "^2.3.1"
-      },
-      "engines": {
-        "node": ">=8.6"
-      }
     },
     "node_modules/minipass": {
       "version": "7.1.3",
@@ -907,20 +706,10 @@
       "version": "1.1.1",
       "license": "ISC"
     },
-    "node_modules/picomatch": {
-      "version": "2.3.2",
-      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.2.tgz",
-      "integrity": "sha512-V7+vQEJ06Z+c5tSye8S+nHUfI51xoXIXjHQ99cQtKUkQqqO1kO/KCJUfZXuB47h/YBlDhah2H3hdUGXn8ie0oA==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=8.6"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/jonschlinkert"
-      }
-    },
     "node_modules/prettier": {
-      "version": "3.8.1",
+      "version": "3.9.6",
+      "resolved": "https://registry.npmjs.org/prettier/-/prettier-3.9.6.tgz",
+      "integrity": "sha512-OpN0zzVdiaiAhxpuuj5efpIS4sY9j7bY6uR5mnj5yPzGkdkjNKSJeUThPb60Jw29QuAZgA4o+/iB49kFiaBX6g==",
       "license": "MIT",
       "bin": {
         "prettier": "bin/prettier.cjs"
@@ -932,64 +721,11 @@
         "url": "https://github.com/prettier/prettier?sponsor=1"
       }
     },
-    "node_modules/queue-microtask": {
-      "version": "1.2.3",
-      "resolved": "https://registry.npmjs.org/queue-microtask/-/queue-microtask-1.2.3.tgz",
-      "integrity": "sha512-NuaNSa6flKT5JaSYQzJok04JzTL1CA6aGhv5rfLW3PgqA+M2ChpZQnAC8h8i4ZFkBS8X5RqkDBHA7r4hej3K9A==",
-      "funding": [
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/feross"
-        },
-        {
-          "type": "patreon",
-          "url": "https://www.patreon.com/feross"
-        },
-        {
-          "type": "consulting",
-          "url": "https://feross.org/support"
-        }
-      ],
-      "license": "MIT"
-    },
     "node_modules/require-from-string": {
       "version": "2.0.2",
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
-      }
-    },
-    "node_modules/reusify": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/reusify/-/reusify-1.1.0.tgz",
-      "integrity": "sha512-g6QUff04oZpHs0eG5p83rFLhHeV00ug/Yf9nZM6fLeUrPguBTkTQOdpAWWspMh55TZfVQDPaN3NQJfbVRAxdIw==",
-      "license": "MIT",
-      "engines": {
-        "iojs": ">=1.0.0",
-        "node": ">=0.10.0"
-      }
-    },
-    "node_modules/run-parallel": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/run-parallel/-/run-parallel-1.2.0.tgz",
-      "integrity": "sha512-5l4VyZR86LZ/lDxZTR6jqL8AFE2S0IFLMP26AbjsLVADxHdhB/c0GUsH+y39UfCi3dzz8OlQuPmnaJOMoDHQBA==",
-      "funding": [
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/feross"
-        },
-        {
-          "type": "patreon",
-          "url": "https://www.patreon.com/feross"
-        },
-        {
-          "type": "consulting",
-          "url": "https://feross.org/support"
-        }
-      ],
-      "license": "MIT",
-      "dependencies": {
-        "queue-microtask": "^1.2.2"
       }
     },
     "node_modules/safer-buffer": {
@@ -1018,18 +754,6 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/isaacs"
-      }
-    },
-    "node_modules/slash": {
-      "version": "5.1.0",
-      "resolved": "https://registry.npmjs.org/slash/-/slash-5.1.0.tgz",
-      "integrity": "sha512-ZA6oR3T/pEyuqwMgAKT0/hAv8oAXckzbkmR0UkUosQ+Mc4RxGoJkRmwHgHufaenlyAgE1Mxgpdcrf75y6XcnDg==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=14.16"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/string-width": {
@@ -1077,63 +801,56 @@
       }
     },
     "node_modules/temporal-polyfill": {
-      "version": "0.3.2",
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/temporal-polyfill/-/temporal-polyfill-1.0.4.tgz",
+      "integrity": "sha512-MLEU0qOD2uXlz24oINNtdLZQl8RgmMxSnRtKEGZGGetTJjlRwQJjk+VsJ4EREaUoiaTb8NJOcUiKtoAiWn9EBg==",
       "license": "MIT",
       "dependencies": {
-        "temporal-spec": "0.3.1"
+        "temporal-spec": "1.0.1",
+        "temporal-utils": "1.0.2"
       }
     },
     "node_modules/temporal-spec": {
-      "version": "0.3.1",
-      "license": "ISC"
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/temporal-spec/-/temporal-spec-1.0.1.tgz",
+      "integrity": "sha512-wxVoanmDeavXie1vu2JaQ3WIc3JZnWAOYFBsJyATaVsXsycKYUflGsyBmrRSnoCpZJpwPyr38VpgSUlQ8CbFxg==",
+      "license": "Apache-2.0"
     },
-    "node_modules/to-regex-range": {
-      "version": "5.0.1",
-      "resolved": "https://registry.npmjs.org/to-regex-range/-/to-regex-range-5.0.1.tgz",
-      "integrity": "sha512-65P7iz6X5yEr1cwcgvQxbbIw7Uk3gOy5dIdtZ4rDveLqhrdJP+Li/Hx6tyK0NEb+2GCyneCMJiGqrADCSNk8sQ==",
-      "license": "MIT",
-      "dependencies": {
-        "is-number": "^7.0.0"
-      },
-      "engines": {
-        "node": ">=8.0"
-      }
-    },
-    "node_modules/unicorn-magic": {
-      "version": "0.4.0",
-      "resolved": "https://registry.npmjs.org/unicorn-magic/-/unicorn-magic-0.4.0.tgz",
-      "integrity": "sha512-wH590V9VNgYH9g3lH9wWjTrUoKsjLF6sGLjhR4sH1LWpLmCOH0Zf7PukhDA8BiS7KHe4oPNkcTHqYkj7SOGUOw==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=20"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
+    "node_modules/temporal-utils": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/temporal-utils/-/temporal-utils-1.0.2.tgz",
+      "integrity": "sha512-1B8Dl4KzrOvsNUlpoWGno2VLQlxroLjDgc5NBjVC9ax9ymdo+ezfyvhyjEMx+IVfhINr6CIG2gcnlP95iRrybQ==",
+      "license": "MIT"
     },
     "node_modules/vscode-jsonrpc": {
-      "version": "8.2.0",
+      "version": "9.0.1",
+      "resolved": "https://registry.npmjs.org/vscode-jsonrpc/-/vscode-jsonrpc-9.0.1.tgz",
+      "integrity": "sha512-rfuA6T75H6m5EkbhtEPzre9pT0HPcDI2MMy4+nPFIBks5J8JBAUHD4tRYSgaBOijIEC7SRkC1kKyXTLqbmh9jw==",
       "license": "MIT",
       "engines": {
         "node": ">=14.0.0"
       }
     },
     "node_modules/vscode-languageserver": {
-      "version": "9.0.1",
+      "version": "10.1.0",
+      "resolved": "https://registry.npmjs.org/vscode-languageserver/-/vscode-languageserver-10.1.0.tgz",
+      "integrity": "sha512-9gEWpXkYGXoqG7pBnE8O8hx/yP7+Aabn4+peQ3KDicQv6qunHSWyLTud3OF0w4S2+HfDD+5HqYKiXQW9HAU6mA==",
       "license": "MIT",
       "dependencies": {
-        "vscode-languageserver-protocol": "3.17.5"
+        "vscode-languageserver-protocol": "3.18.2"
       },
       "bin": {
         "installServerIntoExtension": "bin/installServerIntoExtension"
       }
     },
     "node_modules/vscode-languageserver-protocol": {
-      "version": "3.17.5",
+      "version": "3.18.2",
+      "resolved": "https://registry.npmjs.org/vscode-languageserver-protocol/-/vscode-languageserver-protocol-3.18.2.tgz",
+      "integrity": "sha512-XRyDbT0Pp3sSNti3JmxVEUMySWCSi1hhM+/KUlCy1hV1zmrqpM1OwO12EAki8blhmLuIMpaJrYbo0OzGVfK2Qg==",
       "license": "MIT",
       "dependencies": {
-        "vscode-jsonrpc": "8.2.0",
-        "vscode-languageserver-types": "3.17.5"
+        "vscode-jsonrpc": "9.0.1",
+        "vscode-languageserver-types": "3.18.0"
       }
     },
     "node_modules/vscode-languageserver-textdocument": {
@@ -1141,7 +858,9 @@
       "license": "MIT"
     },
     "node_modules/vscode-languageserver-types": {
-      "version": "3.17.5",
+      "version": "3.18.0",
+      "resolved": "https://registry.npmjs.org/vscode-languageserver-types/-/vscode-languageserver-types-3.18.0.tgz",
+      "integrity": "sha512-8TsGPNMIMiiBdkORgRSvLjuiEIiAFtO+KssmYWxQ+uSVvlf7RjK8YKCOjPzZ+YA04jXEV7+7LvkSmHkhpNS99g==",
       "license": "MIT"
     },
     "node_modules/wrap-ansi": {

--- a/schema/package-lock.json
+++ b/schema/package-lock.json
@@ -6,10 +6,10 @@
     "": {
       "name": "prompty-schema",
       "dependencies": {
-        "@typespec/compiler": "1.10.0",
-        "@typespec/http": "1.10.0",
-        "@typespec/json-schema": "1.10.0",
-        "@typra/emitter": "0.8.7"
+        "@typespec/compiler": "^1.10.0",
+        "@typespec/http": "^1.10.0",
+        "@typespec/json-schema": "^1.10.0",
+        "@typra/emitter": "^0.8.7"
       }
     },
     "node_modules/@babel/code-frame": {

--- a/schema/package.json
+++ b/schema/package.json
@@ -13,9 +13,9 @@
     "build": "npm run lint:fixtures && npm run format:tsp && npm run generate"
   },
   "dependencies": {
-    "@typespec/compiler": "^1.10.0",
-    "@typespec/http": "^1.10.0",
-    "@typespec/json-schema": "^1.10.0",
-    "@typra/emitter": "^0.8.7"
+    "@typespec/compiler": "^1.15.0",
+    "@typespec/http": "^1.15.0",
+    "@typespec/json-schema": "^1.15.0",
+    "@typra/emitter": "^0.9.0"
   }
 }

--- a/schema/package.json
+++ b/schema/package.json
@@ -13,9 +13,9 @@
     "build": "npm run lint:fixtures && npm run format:tsp && npm run generate"
   },
   "dependencies": {
-    "@typespec/compiler": "1.10.0",
-    "@typespec/http": "1.10.0",
-    "@typespec/json-schema": "1.10.0",
-    "@typra/emitter": "0.8.7"
+    "@typespec/compiler": "^1.10.0",
+    "@typespec/http": "^1.10.0",
+    "@typespec/json-schema": "^1.10.0",
+    "@typra/emitter": "^0.8.7"
   }
 }

--- a/schema/tsp-output/.typra-generated/export-surfaces.json
+++ b/schema/tsp-output/.typra-generated/export-surfaces.json
@@ -5,20 +5,20 @@
     "packages": [
       {
         "name": "@typespec/compiler",
-        "version": "1.10.0",
-        "supportedRange": "1.10.0",
+        "version": "1.15.0",
+        "supportedRange": ">=1.10.0 <2.0.0",
         "supported": true
       },
       {
         "name": "@typespec/json-schema",
-        "version": "1.10.0",
-        "supportedRange": "1.10.0",
+        "version": "1.15.0",
+        "supportedRange": ">=1.10.0 <2.0.0",
         "supported": true
       },
       {
         "name": "@typra/emitter",
-        "version": "0.8.7",
-        "supportedRange": "0.8.7",
+        "version": "0.9.0",
+        "supportedRange": "0.9.0",
         "supported": true
       }
     ]


### PR DESCRIPTION
## Summary

Bumps the schema toolchain to **`@typra/emitter@^0.9.0`** (published with peers `>=1.10.0 <2.0.0`) and **`@typespec/*@^1.15.0`**, unblocking the grouped Dependabot `1.10.0 → 1.15.0` upgrade that previously hit `ERESOLVE` against the emitter's old exact `1.10.0` peer pin.

The upstream emitter fix was a **pure peer-range widening** (no emitter code/API changes) — published as `@typra/emitter@0.9.0`.

## What changed here

Only **3 files** — the toolchain lever + its reproducible outputs:
- `schema/package.json` — `@typespec/*` → `^1.15.0`, `@typra/emitter` → `^0.9.0`
- `schema/package-lock.json` — resolves clean to `@typespec 1.15.0` / `@typra/emitter 0.9.0`
- `schema/tsp-output/.typra-generated/export-surfaces.json` — records the intentional toolchain `version` + `supportedRange` bump

**The generated model layer is byte-identical to what is already on `main`.** Regenerating with the pinned `0.9.0` emitter produces zero diff across json-schema, Go, Rust, C#, Python, web, and vscode targets. (The cosmetic TS union-collapse formatting from prettier 3.9.6 already landed independently via #471, so it does not appear here.)

## Validation

- ✅ **`schema-repro-check` (#471) reproduces clean** — ran the exact gate locally (node 22 + prettier 3.9.6 + ruff + gofmt + dotnet format + cargo fmt): `npm run generate` → `git status --porcelain` empty.
- ✅ **`typra-verify`**: classification `patch` — schema types / wire-names / enums / requiredness all `+0`. Only the expected `toolchain.changed` metadata, now baselined.
- ✅ **TS core**: 1807 tests pass, `tsc --noEmit` clean.
- ✅ **Python**: model + loader + parsers + renderers, 894 tests pass; model diff empty.

## Out of scope

**TypeScript 7 remains separately blocked** and is **not** a Typra constraint (the emitter builds with plain `tsc` and declares no `typescript` peer). The blocker is prompty-side: `typescript-eslint` peers `<6.1.0` + the `tsup`/`rollup-plugin-dts` crash on the TS7 compiler API. That is a distinct follow-up track, to re-attempt once `typescript-eslint` publishes a release peering `>=7`.

---
Co-authored-by: Copilot App <223556219+Copilot@users.noreply.github.com>
