### PR TITLE
fix(typescript): eliminate ReDoS in chat parser role-boundary regex

### DIFF
--- a/runtime/typescript/packages/core/src/parsers/prompty.ts
+++ b/runtime/typescript/packages/core/src/parsers/prompty.ts
@@ -21,9 +21,18 @@ import {
 import type { Parser } from "../core/interfaces.js";
 
 // Role boundary regex — matches lines like `system:` or `user[name="Alice"]:`
+//
+// ReDoS hardening: the previous body `((\w+\s*=\s*"?[^"]*"?\s*,?\s*)+)` nested a
+// repetition whose value class overlapped the `\w+=` iteration starter and the
+// separators, so a long attribute run (e.g. `name=aname=a...`) could be partitioned
+// exponentially — catastrophic backtracking. JavaScript has no possessive quantifiers
+// (unlike the Python fix in #457), so instead we remove the nested `+`: require an
+// attribute-like start (`key=`) and then swallow the remainder of the bracket with a
+// single `[^\]]*` class that cannot overlap the closing `]`. This is structurally
+// linear. Individual attributes are still split later by ATTR_RE. See #446.
 const ROLE_NAMES = [...ROLES].filter((r) => r !== "tool").sort().join("|");
 const BOUNDARY_RE = new RegExp(
-  `^\\s*#?\\s*(${ROLE_NAMES})(\\[((\\w+\\s*=\\s*"?[^"]*"?\\s*,?\\s*)+)\\])?\\s*:\\s*$`,
+  `^\\s*#?\\s*(${ROLE_NAMES})(\\[\\w+\\s*=\\s*[^\\]]*\\])?\\s*:\\s*$`,
   "i",
 );
 

--- a/runtime/typescript/packages/core/tests/parsers.test.ts
+++ b/runtime/typescript/packages/core/tests/parsers.test.ts
@@ -59,6 +59,29 @@ Hello!`;
     expect(messages[0].metadata.name).toBe("Alice");
   });
 
+  it("parses multiple unquoted attributes", async () => {
+    const rendered = `user[name=Bob, id=7]:
+Hi`;
+
+    const messages = await parser.parse(agent, rendered);
+    expect(messages).toHaveLength(1);
+    expect(messages[0].role).toBe("user");
+    expect(messages[0].metadata.name).toBe("Bob");
+    expect(messages[0].metadata.id).toBe(7);
+  });
+
+  it("is not vulnerable to ReDoS on adversarial role attributes (#446)", async () => {
+    // Unterminated-quote / unbounded attribute run that triggered catastrophic
+    // backtracking in the old `"?[^"]*"?` value class. Must complete near-instantly.
+    const evil = `user[${"name=a".repeat(24)}"`;
+    const start = performance.now();
+    const messages = await parser.parse(agent, `${evil}:\nHi`);
+    const elapsed = performance.now() - start;
+    expect(elapsed).toBeLessThan(1000);
+    // The adversarial line is not a valid boundary, so it stays as content.
+    expect(messages).toHaveLength(1);
+  });
+
   it("preserves inline markdown images as text", async () => {
     const rendered = `user:
 Look at this ![photo](https://example.com/img.png)`;


### PR DESCRIPTION
## Summary

Eliminates a ReDoS (catastrophic backtracking) vulnerability in the TypeScript chat parser's role-boundary regex — the TypeScript half of #446. The Python half was fixed in #457.

## The bug

The old boundary regex nested a repetition whose value class overlapped both the `\w+=` iteration starter and the separators:

```
(\[((\w+\s*=\s*"?[^"]*"?\s*,?\s*)+)\])?
```

A long attribute-like run with no valid terminator (e.g. `user[name=aname=a...name=a"`) can be partitioned exponentially, so the engine hangs. I confirmed this locally: the adversarial input did not terminate.

## The fix

JavaScript's `RegExp` has no possessive quantifiers or atomic groups (so the Python 3.11 approach in #457 doesn't port). Instead the nested `+` is removed entirely: the bracket now requires an attribute-like start and swallows the remainder of the bracket with a single, non-overlapping class:

```
(\[\w+\s*=\s*[^\]]*\])?
```

This is structurally linear (verified: 40,000-repetition adversarial input matches in ~0.2ms). Individual attributes are still split by the unchanged `ATTR_RE`, so parsing behavior is preserved — including multi-attribute lines like `user[name=Bob, id=7]:` and quoted commas like `user[name="a,b"]:`. Parity holds for negatives too (`user[garbage]:` is still not a boundary).

## Tests

- Added a bounded-runtime regression test (`< 1000ms` on adversarial input).
- Added a multi-unquoted-attribute test (`user[name=Bob, id=7]:`).
- Full core suite: **1809 passed / 17 skipped**, `tsc --noEmit` clean.

Fixes #446