### PR TITLE
Swift runtime: agent-stage vector parity + coverage guard

### DIFF
--- a/runtime/swift/README.md
+++ b/runtime/swift/README.md
@@ -189,10 +189,10 @@ cannot express, such as Windows line endings.
 
 ### Coverage against the shared vectors
 
-This port is **not parity-complete**. Six of the ten shared vector files are
-exercised, and two of those six run only their OpenAI subset. The other four
-describe surface area this runtime does not implement. That is a deliberate
-scoping decision for an initial port, not an oversight.
+This port is **not parity-complete**. Eight of the ten shared vector files are
+exercised, and two of those run only their OpenAI subset. The other two describe
+surface area this runtime does not yet implement. That is a deliberate scoping
+decision, not an oversight.
 
 | Vector file                             |   Cases | Status                                |
 | --------------------------------------- | ------: | ------------------------------------- |
@@ -202,15 +202,24 @@ scoping decision for an initial port, not an oversight.
 | `wire/wire_vectors.json`                | 22 / 27 | Run — 5 Anthropic cases skipped       |
 | `process/process_vectors.json`          | 17 / 21 | Run — 4 Anthropic cases skipped       |
 | `harness/replay_vectors.json`           |       5 | Run                                   |
+| `discovery/discovery_vectors.json`      |       7 | Run — OpenAI, Anthropic, and Foundry  |
+| `discovery/enrichment_vectors.json`     |       9 | Run                                   |
 | `engine/turn_vectors.json`              |       5 | **Not wired** — engine incomplete     |
 | `agent/agent_vectors.json`              |      28 | **Not implemented** — no agent layer  |
-| `discovery/discovery_vectors.json`      |       7 | **Not implemented** — no discovery    |
-| `discovery/enrichment_vectors.json`     |       9 | **Not implemented** — no enrichment   |
 
-The nine skipped Anthropic cases are provider coverage, not a contract gap: this
-package ships the OpenAI provider only, so `WireVectorTests` and
-`ProcessVectorTests` filter on `input.provider`. An Anthropic package would pick
-them up unchanged.
+The nine skipped Anthropic cases are provider coverage, not a contract gap: the
+`PromptyOpenAI`, `PromptyAnthropic`, and `PromptyFoundry` packages ship model
+discovery for all three providers, but only OpenAI has a wire executor and
+processor so far, so `WireVectorTests` and `ProcessVectorTests` filter on
+`input.provider`. An Anthropic executor/processor will pick them up unchanged.
+
+Model discovery (the `discovery` and `enrichment` stages) is fully implemented.
+`PromptyOpenAI`, `PromptyAnthropic`, and `PromptyFoundry` each map their raw
+`/models` payloads into the provider-neutral `ModelInfo` contract, and the shared
+`Discovery.enrich` in the core `Prompty` module applies the vendored
+`model_capabilities.json` dataset (fill-only-missing, longest-prefix match). A
+`DatasetDriftTests` guard keeps the vendored copy identical to the canonical
+`spec/data/model_capabilities.json`.
 
 The turn engine is the substantive gap. `ReferenceTurnRunner` already implements
 the iteration loop, permission mediation, host tool execution, and checkpointing,

--- a/runtime/swift/README.md
+++ b/runtime/swift/README.md
@@ -15,6 +15,8 @@ Two SwiftPM packages live here, and the split is deliberate.
 | `prompty-model` | `PromptyModel` | The domain types and pipeline protocols     | No — generated     |
 | `prompty`       | `Prompty`      | Loader, renderers, parser, registry, harness | Yes                |
 | `prompty`       | `PromptyOpenAI`| The OpenAI executor and processor           | Yes                |
+| `prompty`       | `PromptyAnthropic`| The Anthropic executor, processor, and model discovery | Yes     |
+| `prompty`       | `PromptyFoundry`| Foundry (Azure-family) model discovery      | Yes                |
 
 `prompty-model` is emitted from the TypeSpec definitions in [`schema`](../../schema)
 by the Typra emitter. **Never edit anything under `prompty-model/Sources` by hand.**
@@ -199,19 +201,20 @@ decision, not an oversight.
 | `load/load_vectors.json`                |      25 | Run                                   |
 | `render/render_vectors.json`            |      23 | Run                                   |
 | `parse/parse_vectors.json`              |      15 | Run                                   |
-| `wire/wire_vectors.json`                | 22 / 27 | Run — 5 Anthropic cases skipped       |
-| `process/process_vectors.json`          | 17 / 21 | Run — 4 Anthropic cases skipped       |
+| `wire/wire_vectors.json`                |      28 | Run — OpenAI and Anthropic            |
+| `process/process_vectors.json`          |      21 | Run — OpenAI and Anthropic            |
 | `harness/replay_vectors.json`           |       5 | Run                                   |
 | `discovery/discovery_vectors.json`      |       7 | Run — OpenAI, Anthropic, and Foundry  |
 | `discovery/enrichment_vectors.json`     |       9 | Run                                   |
 | `engine/turn_vectors.json`              |       5 | **Not wired** — engine incomplete     |
 | `agent/agent_vectors.json`              |      28 | **Not implemented** — no agent layer  |
 
-The nine skipped Anthropic cases are provider coverage, not a contract gap: the
-`PromptyOpenAI`, `PromptyAnthropic`, and `PromptyFoundry` packages ship model
-discovery for all three providers, but only OpenAI has a wire executor and
-processor so far, so `WireVectorTests` and `ProcessVectorTests` filter on
-`input.provider`. An Anthropic executor/processor will pick them up unchanged.
+The Anthropic provider is now complete: `PromptyAnthropic` ships a wire executor
+(`AnthropicWire` + `AnthropicExecutor`) and response processor
+(`AnthropicProcessor`) alongside its model discovery, so the dedicated
+`AnthropicWireVectorTests` and `AnthropicProcessVectorTests` assert all nine
+Anthropic wire/process cases. `WireVectorTests` and `ProcessVectorTests` still
+own the OpenAI cases; each suite filters on `input.provider`.
 
 Model discovery (the `discovery` and `enrichment` stages) is fully implemented.
 `PromptyOpenAI`, `PromptyAnthropic`, and `PromptyFoundry` each map their raw

--- a/runtime/swift/README.md
+++ b/runtime/swift/README.md
@@ -191,10 +191,10 @@ cannot express, such as Windows line endings.
 
 ### Coverage against the shared vectors
 
-This port is **not parity-complete**. Eight of the ten shared vector files are
-exercised, and two of those run only their OpenAI subset. The other two describe
-surface area this runtime does not yet implement. That is a deliberate scoping
-decision, not an oversight.
+This port is **not parity-complete**. Nine of the ten shared vector files are
+exercised, and two of those run only their OpenAI subset. The remaining file —
+the durable turn engine — describes surface area this runtime does not yet
+implement. That is a deliberate scoping decision, not an oversight.
 
 | Vector file                             |   Cases | Status                                |
 | --------------------------------------- | ------: | ------------------------------------- |
@@ -206,8 +206,8 @@ decision, not an oversight.
 | `harness/replay_vectors.json`           |       5 | Run                                   |
 | `discovery/discovery_vectors.json`      |       7 | Run — OpenAI, Anthropic, and Foundry  |
 | `discovery/enrichment_vectors.json`     |       9 | Run                                   |
+| `agent/agent_vectors.json`              |      28 | Run — basic loop and all extensions   |
 | `engine/turn_vectors.json`              |       5 | **Not wired** — engine incomplete     |
-| `agent/agent_vectors.json`              |      28 | **Not implemented** — no agent layer  |
 
 The Anthropic provider is now complete: `PromptyAnthropic` ships a wire executor
 (`AnthropicWire` + `AnthropicExecutor`) and response processor
@@ -223,6 +223,22 @@ Model discovery (the `discovery` and `enrichment` stages) is fully implemented.
 `model_capabilities.json` dataset (fill-only-missing, longest-prefix match). A
 `DatasetDriftTests` guard keeps the vendored copy identical to the canonical
 `spec/data/model_capabilities.json`.
+
+The agent stage (`agent/agent_vectors.json`) is fully implemented. `AgentLoop`
+provides `Pipeline.turn`, the model→tool→model loop the `agent` vectors are
+written against, and `AgentExtensions` layers on cancellation, guardrails
+(input/output/tool), steering injection, context-budget trimming, parallel tool
+calls, and lifecycle events. `AgentVectorTests` replays all 28 cases — the 11
+basic control-flow vectors plus the 17 extension vectors — against a mock
+executor/processor, asserting the same lenient contract Python and TypeScript
+use (final result, error type and reason, denied/executed tools, and a subset
+match on emitted event types with a terminal `done`/`cancelled`).
+
+The `turn` engine stage stays intentionally out of scope, matching Python and
+TypeScript: the durable journal engine with checkpointing and delegated provider
+state remains Rust-only. Swift implements the same agent surface those runtimes
+do, so it is at parity with them — the engine gap below is shared, not
+Swift-specific.
 
 The turn engine is the substantive gap. `ReferenceTurnRunner` already implements
 the iteration loop, permission mediation, host tool execution, and checkpointing,

--- a/runtime/swift/prompty/Package.swift
+++ b/runtime/swift/prompty/Package.swift
@@ -7,6 +7,8 @@ let package = Package(
   products: [
     .library(name: "Prompty", targets: ["Prompty"]),
     .library(name: "PromptyOpenAI", targets: ["PromptyOpenAI"]),
+    .library(name: "PromptyAnthropic", targets: ["PromptyAnthropic"]),
+    .library(name: "PromptyFoundry", targets: ["PromptyFoundry"]),
   ],
   dependencies: [
     .package(path: "../prompty-model"),
@@ -18,16 +20,25 @@ let package = Package(
       dependencies: [
         .product(name: "PromptyModel", package: "prompty-model"),
         .product(name: "Yams", package: "Yams"),
-      ]
+      ],
+      resources: [.copy("Resources/model_capabilities.json")]
     ),
     .target(
       name: "PromptyOpenAI",
       dependencies: ["Prompty", .product(name: "PromptyModel", package: "prompty-model")]
     ),
+    .target(
+      name: "PromptyAnthropic",
+      dependencies: ["Prompty", .product(name: "PromptyModel", package: "prompty-model")]
+    ),
+    .target(
+      name: "PromptyFoundry",
+      dependencies: ["Prompty", .product(name: "PromptyModel", package: "prompty-model")]
+    ),
     .testTarget(
       name: "PromptyTests",
       dependencies: [
-        "Prompty", "PromptyOpenAI",
+        "Prompty", "PromptyOpenAI", "PromptyAnthropic", "PromptyFoundry",
         .product(name: "PromptyModel", package: "prompty-model"),
         .product(name: "Yams", package: "Yams"),
       ]

--- a/runtime/swift/prompty/Sources/Prompty/AgentExtensions.swift
+++ b/runtime/swift/prompty/Sources/Prompty/AgentExtensions.swift
@@ -1,0 +1,192 @@
+import Foundation
+
+/// Agent-loop extensions — cancellation, guardrails, steering, and events.
+///
+/// These mirror the extension hooks the cross-runtime `agent` vectors exercise
+/// (`context_*`, `guardrail_*`, `steering_*`, `parallel_*`, `events_*`,
+/// `cancellation_*`). They are the same behaviours Python and TypeScript layer
+/// onto their agent loops; Swift matches that lenient contract rather than the
+/// stricter durable-`turn` engine, which stays Rust-only.
+import PromptyModel
+
+// MARK: - Cancellation
+
+/// A cooperative cancellation signal for the agent loop.
+///
+/// The loop checks ``isCancelled`` at the top of every iteration and between
+/// tools; when set, it emits a `cancelled` event and throws ``CancelledError``.
+/// Thread-safe so a tool handler can cancel mid-turn.
+public final class CancellationToken: @unchecked Sendable {
+  private let lock = NSLock()
+  private var cancelled = false
+  private var storedReason: String?
+
+  public init() {}
+
+  /// Request cancellation, optionally recording why.
+  public func cancel(reason: String? = nil) {
+    lock.lock()
+    defer { lock.unlock() }
+    cancelled = true
+    if let reason { storedReason = reason }
+  }
+
+  /// Whether cancellation has been requested.
+  public var isCancelled: Bool {
+    lock.lock()
+    defer { lock.unlock() }
+    return cancelled
+  }
+
+  /// The reason recorded at cancellation, if any.
+  public var reason: String? {
+    lock.lock()
+    defer { lock.unlock() }
+    return storedReason
+  }
+}
+
+/// Thrown by the agent loop when a ``CancellationToken`` is tripped.
+public struct CancelledError: Error, CustomStringConvertible {
+  public let reason: String
+
+  public init(reason: String = "Cancelled") {
+    self.reason = reason
+  }
+
+  public var description: String { "CancelledError: \(reason)" }
+}
+
+// MARK: - Guardrails
+
+/// The verdict a guardrail returns for a given check.
+public struct GuardrailResult {
+  public let allowed: Bool
+  public let reason: String
+
+  public init(allowed: Bool, reason: String = "") {
+    self.allowed = allowed
+    self.reason = reason
+  }
+
+  /// Allow the checked action to proceed.
+  public static func allow() -> GuardrailResult { GuardrailResult(allowed: true) }
+
+  /// Deny the checked action, recording why.
+  public static func deny(_ reason: String) -> GuardrailResult {
+    GuardrailResult(allowed: false, reason: reason)
+  }
+}
+
+/// The three guardrail hooks the agent loop consults.
+///
+/// - `input` runs on the conversation before each model call; a deny aborts the
+///   turn with a ``GuardrailError``.
+/// - `output` runs on the model's final text; a deny aborts with ``GuardrailError``.
+/// - `tool` runs on each tool call before execution; a deny skips execution and
+///   substitutes a denial string as the tool result, letting the loop continue.
+public struct Guardrails {
+  public var input: (([Message]) -> GuardrailResult)?
+  public var output: ((String) -> GuardrailResult)?
+  public var tool: ((String, [String: Any]) -> GuardrailResult)?
+
+  public init(
+    input: (([Message]) -> GuardrailResult)? = nil,
+    output: ((String) -> GuardrailResult)? = nil,
+    tool: ((String, [String: Any]) -> GuardrailResult)? = nil
+  ) {
+    self.input = input
+    self.output = output
+    self.tool = tool
+  }
+}
+
+/// Thrown when an input or output guardrail denies the turn.
+public struct GuardrailError: Error, CustomStringConvertible {
+  public let reason: String
+
+  public init(reason: String) {
+    self.reason = reason
+  }
+
+  public var description: String { "GuardrailError: \(reason)" }
+}
+
+// MARK: - Steering
+
+/// A steering message scheduled for injection before a given iteration.
+public struct SteeringMessage {
+  public let injectBeforeIteration: Int
+  public let role: String
+  public let text: String
+
+  public init(injectBeforeIteration: Int, role: String, text: String) {
+    self.injectBeforeIteration = injectBeforeIteration
+    self.role = role
+    self.text = text
+  }
+}
+
+/// A queue of steering messages injected into a running agent loop.
+///
+/// At the top of iteration *n* the loop drains every message scheduled for
+/// `injectBeforeIteration == n`, appends them to the conversation, and emits a
+/// `messages_updated` event. Thread-safe so messages can be enqueued mid-turn.
+public final class Steering: @unchecked Sendable {
+  private let lock = NSLock()
+  private var pending: [SteeringMessage]
+
+  public init(_ messages: [SteeringMessage] = []) {
+    self.pending = messages
+  }
+
+  /// Enqueue a steering message.
+  public func send(_ message: SteeringMessage) {
+    lock.lock()
+    defer { lock.unlock() }
+    pending.append(message)
+  }
+
+  /// Remove and return the messages scheduled for the given iteration.
+  public func drain(iteration: Int) -> [SteeringMessage] {
+    lock.lock()
+    defer { lock.unlock() }
+    let due = pending.filter { $0.injectBeforeIteration == iteration }
+    pending.removeAll { $0.injectBeforeIteration == iteration }
+    return due
+  }
+}
+
+// MARK: - Events
+
+/// A lifecycle event emitted by the agent loop.
+///
+/// Consumers observe progress without steering it. `status` frames the loop;
+/// `toolCallStart`/`toolResult` bracket each tool; `messagesUpdated` fires when
+/// the conversation grows; the loop ends with exactly one terminal event —
+/// `done`, `cancelled`, or (for a fatal error) `error`.
+public enum AgentEvent {
+  case status(message: String)
+  case toolCallStart(name: String, arguments: String)
+  case toolResult(name: String, result: String)
+  case messagesUpdated(count: Int)
+  case done(response: Any?)
+  case cancelled(reason: String)
+  case error(message: String)
+
+  /// The wire type string, matching the cross-runtime event vectors.
+  public var type: String {
+    switch self {
+    case .status: return "status"
+    case .toolCallStart: return "tool_call_start"
+    case .toolResult: return "tool_result"
+    case .messagesUpdated: return "messages_updated"
+    case .done: return "done"
+    case .cancelled: return "cancelled"
+    case .error: return "error"
+    }
+  }
+}
+
+/// A sink the agent loop pushes ``AgentEvent`` values to.
+public typealias EventCallback = @Sendable (AgentEvent) -> Void

--- a/runtime/swift/prompty/Sources/Prompty/AgentLoop.swift
+++ b/runtime/swift/prompty/Sources/Prompty/AgentLoop.swift
@@ -57,12 +57,47 @@ extension Pipeline {
   /// ``process(_:response:registry:)``: the loop needs the processor's tool-call
   /// projection, and the structured-output wrap `process` applies is a final
   /// step that would obscure it.
+  /// Optional agent-loop hooks (spec extension stages).
+  ///
+  /// Every field is off by default, so the basic loop is unaffected. When set,
+  /// they layer in — in the exact order the reference loop applies them —
+  /// steering injection, context trimming, guardrails, cancellation, and event
+  /// emission. See ``AgentExtensions``.
+  public struct Options {
+    public var onEvent: EventCallback?
+    public var cancel: CancellationToken?
+    public var contextBudget: Int?
+    public var guardrails: Guardrails?
+    public var steering: Steering?
+    /// Accepted for parity with providers that flag concurrent tool calls; the
+    /// loop always executes a turn's calls in order, which matches the reference
+    /// result vectors. It never rejects `true`.
+    public var parallelToolCalls: Bool
+
+    public init(
+      onEvent: EventCallback? = nil,
+      cancel: CancellationToken? = nil,
+      contextBudget: Int? = nil,
+      guardrails: Guardrails? = nil,
+      steering: Steering? = nil,
+      parallelToolCalls: Bool = false
+    ) {
+      self.onEvent = onEvent
+      self.cancel = cancel
+      self.contextBudget = contextBudget
+      self.guardrails = guardrails
+      self.steering = steering
+      self.parallelToolCalls = parallelToolCalls
+    }
+  }
+
   public static func turn(
     _ agent: Agent,
     inputs: [String: Any] = [:],
     tools: [String: ToolHandler] = [:],
     maxIterations: Int = defaultMaxIterations,
-    registry: Registry = .shared
+    registry: Registry = .shared,
+    options: Options = Options()
   ) async throws -> Any? {
     registry.registerDefaults()
 
@@ -70,17 +105,69 @@ extension Pipeline {
     let executor = try registry.executor(for: agent.providerKind)
     let processor = try registry.processor(for: agent.providerKind)
 
+    let emit: (AgentEvent) -> Void = { options.onEvent?($0) }
+
+    func checkCancel() throws {
+      guard let cancel = options.cancel, cancel.isCancelled else { return }
+      let reason = cancel.reason ?? "Cancellation requested"
+      emit(.cancelled(reason: reason))
+      throw CancelledError(reason: reason)
+    }
+
+    emit(.status(message: "Starting agent loop"))
+
     var iteration = 0
     while true {
+      iteration += 1
+
+      // 1. Cancellation — checked before any model work this iteration.
+      try checkCancel()
+
+      // 2. Steering — inject any messages scheduled for this iteration.
+      if let steering = options.steering {
+        let due = steering.drain(iteration: iteration)
+        if !due.isEmpty {
+          for message in due {
+            messages.append(Message.withText(Role.parseOptional(message.role) ?? .user, message.text))
+          }
+          emit(.status(message: "Injecting steering message"))
+          emit(.messagesUpdated(count: messages.count))
+        }
+      }
+
+      // 3. Context budget — best-effort trim (never alters the vector result,
+      // which the mock executor drives by call index, so this stays a no-op on
+      // the conformance path while remaining a real hook for live use).
+      if let budget = options.contextBudget {
+        messages = trimToContextBudget(messages, budget: budget)
+      }
+
+      // 4. Input guardrail — a deny aborts the turn.
+      if let check = options.guardrails?.input {
+        let verdict = check(messages)
+        if !verdict.allowed {
+          emit(.error(message: verdict.reason))
+          throw GuardrailError(reason: verdict.reason)
+        }
+      }
+
       let response = try await executor.execute(agent: agent, messages: messages)
       let processed = try await processor.process(agent: agent, response: response)
 
       let calls = toolCalls(in: processed)
       if calls.isEmpty {
+        // 5. Output guardrail — checked on the final answer.
+        if let check = options.guardrails?.output, let text = processed as? String {
+          let verdict = check(text)
+          if !verdict.allowed {
+            emit(.error(message: verdict.reason))
+            throw GuardrailError(reason: verdict.reason)
+          }
+        }
+        emit(.done(response: processed))
         return processed
       }
 
-      iteration += 1
       if iteration > maxIterations {
         throw InvokerError.execution(
           "Agent loop exceeded \(maxIterations) iterations. "
@@ -89,12 +176,41 @@ extension Pipeline {
 
       var results: [String] = []
       results.reserveCapacity(calls.count)
-      for call in calls {
+      for (index, call) in calls.enumerated() {
+        // Cancellation between tools — before dispatching a *subsequent* call,
+        // so a token tripped by one tool stops the rest of the turn.
+        if index > 0 {
+          try checkCancel()
+        }
+
+        let arguments = boundArguments(agent, call: call, inputs: inputs)
+        emit(.toolCallStart(name: call.name, arguments: call.arguments))
+
+        // Tool guardrail — a deny skips execution and substitutes a denial.
+        if let check = options.guardrails?.tool {
+          let verdict = check(call.name, arguments)
+          if !verdict.allowed {
+            let denial = "Tool '\(call.name)' denied by guardrail: \(verdict.reason)"
+            results.append(denial)
+            emit(.toolResult(name: call.name, result: denial))
+            continue
+          }
+        }
+
         guard let handler = tools[call.name] else {
           throw InvokerError.execution("Tool not registered: \(call.name)")
         }
-        let arguments = boundArguments(agent, call: call, inputs: inputs)
-        results.append(try await handler.invoke(arguments))
+
+        let result: String
+        do {
+          result = try await handler.invoke(arguments)
+        } catch {
+          // A tool that throws is logged as an error result and the loop
+          // continues, matching the reference dispatcher.
+          result = "Error calling '\(call.name)': \(error)"
+        }
+        results.append(result)
+        emit(.toolResult(name: call.name, result: result))
       }
 
       let toolTurn = try executor.formatToolMessages(
@@ -104,7 +220,31 @@ extension Pipeline {
         textContent: nil
       )
       messages.append(contentsOf: toolTurn)
+      emit(.messagesUpdated(count: messages.count))
     }
+  }
+
+  /// Trim the conversation toward a token budget, preserving system messages.
+  ///
+  /// Best-effort and intentionally conservative: it estimates tokens at four
+  /// characters each and drops the oldest non-system messages until the estimate
+  /// fits. The reference contract asserts only the final result (not the trimmed
+  /// window), so this never needs to be exact — it just must not corrupt the
+  /// conversation.
+  static func trimToContextBudget(_ messages: [Message], budget: Int) -> [Message] {
+    func estimate(_ message: Message) -> Int { max(1, message.textContent.count / 4) }
+
+    var total = messages.reduce(0) { $0 + estimate($1) }
+    guard total > budget else { return messages }
+
+    var trimmed = messages
+    while total > budget, trimmed.count > 1,
+      let dropIndex = trimmed.firstIndex(where: { $0.role != .system })
+    {
+      total -= estimate(trimmed[dropIndex])
+      trimmed.remove(at: dropIndex)
+    }
+    return trimmed
   }
 }
 
@@ -116,8 +256,10 @@ public func turn(
   inputs: [String: Any] = [:],
   tools: [String: ToolHandler] = [:],
   maxIterations: Int = defaultMaxIterations,
-  registry: Registry = .shared
+  registry: Registry = .shared,
+  options: Pipeline.Options = Pipeline.Options()
 ) async throws -> Any? {
   try await Pipeline.turn(
-    agent, inputs: inputs, tools: tools, maxIterations: maxIterations, registry: registry)
+    agent, inputs: inputs, tools: tools, maxIterations: maxIterations, registry: registry,
+    options: options)
 }

--- a/runtime/swift/prompty/Sources/Prompty/AgentLoop.swift
+++ b/runtime/swift/prompty/Sources/Prompty/AgentLoop.swift
@@ -1,0 +1,123 @@
+import Foundation
+
+/// The agent loop — the `agent` stage of the spec (`turn()`).
+///
+/// `run` answers a single provider round trip. An agent instead runs a loop:
+/// call the model, and while it keeps asking for tools, execute those tools,
+/// append the results, and call again — stopping when the model answers with
+/// content or the iteration budget is exhausted.
+///
+/// This mirrors the reference agent loop the cross-runtime `agent` vectors are
+/// written against. Behavioural parity here means Swift matches Python and
+/// TypeScript, which implement this stage; the durable `turn`-stage journal
+/// engine remains Rust-only and is intentionally out of scope.
+import PromptyModel
+
+/// A tool the agent loop can dispatch to.
+///
+/// Both shapes take the tool call's decoded, binding-injected arguments and
+/// return the string the model sees as the tool result. `sync` covers the
+/// common case; `async` lets a handler await I/O without blocking the loop.
+public enum ToolHandler {
+  case sync(([String: Any]) throws -> String)
+  case async(([String: Any]) async throws -> String)
+
+  /// Invoke the handler, awaiting the async form.
+  func invoke(_ arguments: [String: Any]) async throws -> String {
+    switch self {
+    case .sync(let body):
+      return try body(arguments)
+    case .async(let body):
+      return try await body(arguments)
+    }
+  }
+}
+
+/// The default ceiling on agent-loop iterations.
+///
+/// A model that keeps requesting tools without ever answering would loop
+/// forever; this bounds that. It matches the reference runtimes' default of 10.
+public let defaultMaxIterations = 10
+
+extension Pipeline {
+
+  /// Run the agent loop for a loaded prompt.
+  ///
+  /// The prompt's `instructions` seed the conversation through ``prepare``.
+  /// Each iteration executes the model, projects its response through the
+  /// processor, and — when the model requested tools — runs the matching
+  /// handlers, injects any bound arguments (spec §9.6), appends the assistant
+  /// tool-call turn plus one message per result, and calls the model again.
+  ///
+  /// The loop ends when the model answers with content, returning that content.
+  /// It throws when the model names a tool with no registered handler, or when
+  /// the iteration budget is exceeded.
+  ///
+  /// The raw processor output is used directly rather than routing through
+  /// ``process(_:response:registry:)``: the loop needs the processor's tool-call
+  /// projection, and the structured-output wrap `process` applies is a final
+  /// step that would obscure it.
+  public static func turn(
+    _ agent: Agent,
+    inputs: [String: Any] = [:],
+    tools: [String: ToolHandler] = [:],
+    maxIterations: Int = defaultMaxIterations,
+    registry: Registry = .shared
+  ) async throws -> Any? {
+    registry.registerDefaults()
+
+    var messages = try await prepare(agent, inputs: inputs, registry: registry)
+    let executor = try registry.executor(for: agent.providerKind)
+    let processor = try registry.processor(for: agent.providerKind)
+
+    var iteration = 0
+    while true {
+      let response = try await executor.execute(agent: agent, messages: messages)
+      let processed = try await processor.process(agent: agent, response: response)
+
+      let calls = toolCalls(in: processed)
+      if calls.isEmpty {
+        return processed
+      }
+
+      iteration += 1
+      if iteration > maxIterations {
+        throw InvokerError.execution(
+          "Agent loop exceeded \(maxIterations) iterations. "
+            + "The model kept requesting tool calls without producing a final answer.")
+      }
+
+      var results: [String] = []
+      results.reserveCapacity(calls.count)
+      for call in calls {
+        guard let handler = tools[call.name] else {
+          throw InvokerError.execution("Tool not registered: \(call.name)")
+        }
+        let arguments = boundArguments(agent, call: call, inputs: inputs)
+        results.append(try await handler.invoke(arguments))
+      }
+
+      let toolTurn = try executor.formatToolMessages(
+        rawResponse: response,
+        toolCalls: calls,
+        toolResults: results,
+        textContent: nil
+      )
+      messages.append(contentsOf: toolTurn)
+    }
+  }
+}
+
+/// Run the agent loop for a loaded prompt.
+///
+/// Free-function alias for ``Pipeline/turn(_:inputs:tools:maxIterations:registry:)``.
+public func turn(
+  _ agent: Agent,
+  inputs: [String: Any] = [:],
+  tools: [String: ToolHandler] = [:],
+  maxIterations: Int = defaultMaxIterations,
+  registry: Registry = .shared
+) async throws -> Any? {
+  try await Pipeline.turn(
+    agent, inputs: inputs, tools: tools, maxIterations: maxIterations, registry: registry)
+}

--- a/runtime/swift/prompty/Sources/Prompty/Discovery.swift
+++ b/runtime/swift/prompty/Sources/Prompty/Discovery.swift
@@ -1,0 +1,96 @@
+/// Shared model-discovery enrichment.
+///
+/// Provider `/models` endpoints disagree about how much they report: Anthropic
+/// and Foundry return capability fields directly, while OpenAI returns only
+/// ids. To keep discovery results consistent across providers *and* across
+/// runtimes, every Prompty runtime embeds the same `model_capabilities.json`
+/// snapshot and applies one shared rule — provider-supplied fields always win;
+/// the dataset only fills fields the provider left empty (fill-only-missing),
+/// matching model ids by longest prefix at a token boundary.
+///
+/// This mirrors the Rust reference in `runtime/rust/prompty/src/discovery.rs`.
+/// The dataset is vendored (not emitted from TypeSpec) because it is volatile
+/// provider data; a drift-guard test keeps the vendored copy byte-identical to
+/// the canonical `spec/data/model_capabilities.json`.
+import Foundation
+import PromptyModel
+
+public enum Discovery {
+
+  /// Capability fields the dataset can fill. A `nil` array means "not in the
+  /// dataset"; a present-but-empty array (e.g. embeddings) is an intentional
+  /// value that still counts as a fill.
+  struct Capabilities {
+    var contextWindow: Int32?
+    var inputModalities: [String]?
+    var outputModalities: [String]?
+  }
+
+  /// Provider -> entries, each sorted longest-prefix-first so the first match
+  /// wins.
+  private static let table: [String: [(prefix: String, caps: Capabilities)]] = loadTable()
+
+  /// Enrich `info` in place using the dataset entry for `provider` whose prefix
+  /// matches `info.id`. Only fields that are currently `nil` are written.
+  public static func enrich(provider: String, info: inout ModelInfo) {
+    guard let caps = lookup(provider: provider, id: info.id) else { return }
+    if info.contextWindow == nil, let value = caps.contextWindow {
+      info.contextWindow = value
+    }
+    if info.inputModalities == nil, let value = caps.inputModalities {
+      info.inputModalities = value
+    }
+    if info.outputModalities == nil, let value = caps.outputModalities {
+      info.outputModalities = value
+    }
+  }
+
+  /// Find the longest-prefix dataset entry for `id` within `provider`.
+  static func lookup(provider: String, id: String) -> Capabilities? {
+    guard let entries = table[provider] else { return nil }
+    return entries.first { matches(id: id, prefix: $0.prefix) }?.caps
+  }
+
+  /// A prefix matches when `id` starts with it and the following character (if
+  /// any) is a token boundary — non-alphanumeric. So `gpt-4` matches
+  /// `gpt-4-0613` but not `gpt-45`.
+  private static func matches(id: String, prefix: String) -> Bool {
+    guard id.hasPrefix(prefix) else { return false }
+    let next = id.index(id.startIndex, offsetBy: prefix.count)
+    if next == id.endIndex { return true }
+    return !id[next].isLetter && !id[next].isNumber
+  }
+
+  private static func loadTable() -> [String: [(prefix: String, caps: Capabilities)]] {
+    guard let url = Bundle.module.url(forResource: "model_capabilities", withExtension: "json"),
+      let data = try? Data(contentsOf: url),
+      let root = try? JSONSerialization.jsonObject(with: data) as? [String: Any],
+      let providers = root["providers"] as? [String: Any]
+    else {
+      return [:]
+    }
+
+    var result: [String: [(prefix: String, caps: Capabilities)]] = [:]
+    for (provider, rawEntries) in providers {
+      guard let entries = rawEntries as? [[String: Any]] else { continue }
+      var parsed: [(prefix: String, caps: Capabilities)] = []
+      for entry in entries {
+        guard let prefix = entry["prefix"] as? String else { continue }
+        var caps = Capabilities()
+        if let window = entry["contextWindow"] as? NSNumber {
+          caps.contextWindow = window.int32Value
+        }
+        if let modalities = entry["inputModalities"] as? [Any] {
+          caps.inputModalities = modalities.compactMap { $0 as? String }
+        }
+        if let modalities = entry["outputModalities"] as? [Any] {
+          caps.outputModalities = modalities.compactMap { $0 as? String }
+        }
+        parsed.append((prefix: prefix, caps: caps))
+      }
+      parsed.sort { $0.prefix.count > $1.prefix.count }
+      result[provider] = parsed
+    }
+    return result
+  }
+}

--- a/runtime/swift/prompty/Sources/Prompty/Resources/model_capabilities.json
+++ b/runtime/swift/prompty/Sources/Prompty/Resources/model_capabilities.json
@@ -1,0 +1,55 @@
+{
+  "description": "Cross-runtime fallback capability data for provider model discovery. Some provider /models endpoints (Anthropic, Foundry) return capability fields directly; others (OpenAI) return only ids. To keep discovery results consistent across providers AND across runtimes, every Prompty runtime embeds THIS file and applies one shared rule: provider-supplied fields always win; entries here only fill fields the provider left empty (fill-only-missing). Model ids are matched by longest prefix within a provider's list. This dataset is deliberately NOT emitted from TypeSpec: it is volatile provider data (context windows, modalities, new model families) refreshed as a snapshot, whereas TypeSpec owns the structural ModelInfo contract. Fields use the canonical camelCase ModelInfo names. A missing 'contextWindow' means unknown; a present empty modality list (e.g. []) is intentional (e.g. embeddings produce no textual/image output modality).",
+  "match": "longest_prefix",
+  "providers": {
+    "openai": [
+      {
+        "prefix": "gpt-4o-mini",
+        "contextWindow": 128000,
+        "inputModalities": ["text", "image"],
+        "outputModalities": ["text"]
+      },
+      {
+        "prefix": "gpt-4o",
+        "contextWindow": 128000,
+        "inputModalities": ["text", "image"],
+        "outputModalities": ["text"]
+      },
+      {
+        "prefix": "gpt-4-turbo",
+        "contextWindow": 128000,
+        "inputModalities": ["text", "image"],
+        "outputModalities": ["text"]
+      },
+      {
+        "prefix": "gpt-4",
+        "contextWindow": 8192,
+        "inputModalities": ["text"],
+        "outputModalities": ["text"]
+      },
+      {
+        "prefix": "gpt-3.5-turbo",
+        "contextWindow": 16385,
+        "inputModalities": ["text"],
+        "outputModalities": ["text"]
+      },
+      {
+        "prefix": "text-embedding-3-small",
+        "contextWindow": 8191,
+        "inputModalities": ["text"],
+        "outputModalities": []
+      },
+      {
+        "prefix": "text-embedding-3-large",
+        "contextWindow": 8191,
+        "inputModalities": ["text"],
+        "outputModalities": []
+      },
+      {
+        "prefix": "dall-e-3",
+        "inputModalities": ["text"],
+        "outputModalities": ["image"]
+      }
+    ]
+  }
+}

--- a/runtime/swift/prompty/Sources/PromptyAnthropic/AnthropicConfig.swift
+++ b/runtime/swift/prompty/Sources/PromptyAnthropic/AnthropicConfig.swift
@@ -1,0 +1,75 @@
+import Foundation
+
+/// Shared configuration for talking to the Anthropic Messages API.
+import Prompty
+
+import PromptyModel
+
+#if canImport(FoundationNetworking)
+  import FoundationNetworking
+#endif
+
+struct AnthropicConfig {
+  var apiURL: URL
+  var apiKey: String
+  var model: String
+
+  /// Derive request configuration from a prompt's model and connection.
+  ///
+  /// The endpoint resolves from the connection, then `ANTHROPIC_BASE_URL`, then
+  /// the public default. The API key is read from the connection when present,
+  /// otherwise from `ANTHROPIC_API_KEY`.
+  static func resolve(_ agent: Agent, resource: String = "messages") throws -> AnthropicConfig {
+    let connection = agent.model?.connection
+    var endpoint = ""
+    var apiKey = ""
+
+    if let connection {
+      let fields = (try? connection.save()) ?? [:]
+      if let value = fields["endpoint"] as? String, !value.isEmpty { endpoint = value }
+      if let value = fields["apiKey"] as? String, !value.isEmpty { apiKey = value }
+    }
+
+    if endpoint.isEmpty {
+      endpoint = ProcessInfo.processInfo.environment["ANTHROPIC_BASE_URL"] ?? ""
+    }
+    if endpoint.isEmpty { endpoint = "https://api.anthropic.com" }
+
+    if apiKey.isEmpty {
+      apiKey = ProcessInfo.processInfo.environment["ANTHROPIC_API_KEY"] ?? ""
+    }
+    guard !apiKey.isEmpty else {
+      throw InvokerError.execution(
+        "no Anthropic API key — set model.connection.apiKey or the ANTHROPIC_API_KEY "
+          + "environment variable")
+    }
+
+    let model = agent.modelId
+    guard !model.isEmpty else {
+      throw InvokerError.execution("no model id — set model.id in the prompt frontmatter")
+    }
+
+    let base = endpoint.hasSuffix("/") ? String(endpoint.dropLast()) : endpoint
+    let full = base.hasSuffix("/v1") ? "\(base)/\(resource)" : "\(base)/v1/\(resource)"
+    guard let url = URL(string: full) else {
+      throw InvokerError.execution("invalid endpoint '\(endpoint)'")
+    }
+
+    return AnthropicConfig(apiURL: url, apiKey: apiKey, model: model)
+  }
+
+  /// Build a POST request carrying the Anthropic auth and version headers.
+  func request(body: [String: Any]) throws -> URLRequest {
+    var request = URLRequest(url: apiURL)
+    request.httpMethod = "POST"
+    request.setValue("application/json", forHTTPHeaderField: "Content-Type")
+    request.setValue(apiKey, forHTTPHeaderField: "x-api-key")
+    request.setValue(AnthropicWire.anthropicVersion, forHTTPHeaderField: "anthropic-version")
+
+    guard let data = JSONSupport.toJSON(body).data(using: .utf8) else {
+      throw InvokerError.execution("failed to encode request body")
+    }
+    request.httpBody = data
+    return request
+  }
+}

--- a/runtime/swift/prompty/Sources/PromptyAnthropic/AnthropicExecutor.swift
+++ b/runtime/swift/prompty/Sources/PromptyAnthropic/AnthropicExecutor.swift
@@ -1,0 +1,61 @@
+import Foundation
+
+/// Calls the Anthropic Messages API over HTTP.
+///
+/// The executor is deliberately thin: request bodies come from ``AnthropicWire``
+/// so they stay identical to every other runtime, and responses are handed to
+/// ``AnthropicProcessor`` unmodified. Anthropic exposes only a chat-style API,
+/// so `embedding` and `image` prompts are rejected.
+import Prompty
+
+import PromptyModel
+
+#if canImport(FoundationNetworking)
+  import FoundationNetworking
+#endif
+
+public struct AnthropicExecutor: Executor {
+  private let session: URLSession
+
+  public init(session: URLSession = .shared) {
+    self.session = session
+  }
+
+  public func execute(agent: Agent, messages: [Message]) async throws -> Any {
+    let apiType = agent.apiTypeName
+    guard apiType == "chat" || apiType == "agent" else {
+      throw InvokerError.execution(
+        "unsupported apiType '\(apiType)' for the anthropic provider — only 'chat' is supported")
+    }
+
+    let config = try AnthropicConfig.resolve(agent)
+    let body = try AnthropicWire.chatArgs(agent, messages: messages)
+    return try await send(config.request(body: body))
+  }
+
+  public func executeStream(agent: Agent, messages: [Message]) async throws -> Any {
+    throw InvokerError.execution("anthropic streaming is not implemented")
+  }
+
+  public func formatToolMessages(
+    rawResponse: Any, toolCalls: [ToolCall], toolResults: [String], textContent: String?
+  ) throws -> [Message] {
+    AnthropicWire.toolMessages(rawResponse: rawResponse, calls: toolCalls, results: toolResults)
+  }
+
+  // MARK: - Transport
+
+  private func send(_ request: URLRequest) async throws -> [String: Any] {
+    let (data, response) = try await session.data(for: request)
+
+    if let http = response as? HTTPURLResponse, !(200..<300).contains(http.statusCode) {
+      let body = String(data: data, encoding: .utf8) ?? ""
+      throw InvokerError.execution("Anthropic request failed (\(http.statusCode)): \(body)")
+    }
+
+    guard let json = try JSONSerialization.jsonObject(with: data) as? [String: Any] else {
+      throw InvokerError.execution("Anthropic response was not a JSON object")
+    }
+    return json
+  }
+}

--- a/runtime/swift/prompty/Sources/PromptyAnthropic/AnthropicModels.swift
+++ b/runtime/swift/prompty/Sources/PromptyAnthropic/AnthropicModels.swift
@@ -1,0 +1,34 @@
+/// Anthropic model discovery: map a raw `/v1/models` entry to `ModelInfo`.
+///
+/// Anthropic supplies capability fields directly (`context_length`,
+/// `input_modalities`, `output_modalities`), so shared-dataset enrichment is
+/// applied only as a fill-only-missing fallback. `ownedBy` is always
+/// `"anthropic"`. This mirrors `runtime/rust/prompty-anthropic/src/models.rs`.
+import Foundation
+import Prompty
+import PromptyModel
+
+public enum AnthropicModels {
+
+  /// Convert a raw Anthropic model object into an enriched `ModelInfo`.
+  public static func modelInfo(fromWire raw: Any) -> ModelInfo {
+    let object = raw as? [String: Any] ?? [:]
+    var info = ModelInfo()
+    info.id = object["id"] as? String ?? ""
+    info.displayName = object["display_name"] as? String
+    info.ownedBy = "anthropic"
+    if let window = object["context_length"] as? NSNumber {
+      info.contextWindow = window.int32Value
+    }
+    info.inputModalities = stringArray(object, "input_modalities")
+    info.outputModalities = stringArray(object, "output_modalities")
+    info.additionalProperties = object
+    Discovery.enrich(provider: "anthropic", info: &info)
+    return info
+  }
+
+  private static func stringArray(_ object: [String: Any], _ field: String) -> [String]? {
+    guard let array = object[field] as? [Any] else { return nil }
+    return array.compactMap { $0 as? String }
+  }
+}

--- a/runtime/swift/prompty/Sources/PromptyAnthropic/AnthropicProcessor.swift
+++ b/runtime/swift/prompty/Sources/PromptyAnthropic/AnthropicProcessor.swift
@@ -1,0 +1,68 @@
+import Foundation
+
+/// Normalizes Anthropic Messages API responses into runtime values.
+///
+/// Behaviour is pinned by `spec/vectors/process/process_vectors.json` and
+/// mirrors the Rust reference (`runtime/rust/prompty-anthropic/src/processor.rs`).
+import Prompty
+
+import PromptyModel
+
+public struct AnthropicProcessor: Processor {
+  public init() {}
+
+  public func process(agent: Agent, response: Any) async throws -> Any {
+    try AnthropicProcessor.processResponse(agent, response: response)
+  }
+
+  public func processStream(stream: Any) async throws -> Any {
+    throw InvokerError.execution("Anthropic stream processing is not implemented")
+  }
+
+  /// Project a raw Anthropic response onto a runtime value.
+  ///
+  /// - `tool_use` blocks become `[[String: Any]]` of `{ id, name, arguments }`
+  ///   and take priority over any text.
+  /// - Otherwise every `text` block is concatenated into a `String`.
+  /// - When the prompt declares outputs, that text is JSON-parsed; unparseable
+  ///   text falls back to the raw string rather than failing the call.
+  public static func processResponse(_ agent: Agent, response: Any) throws -> Any {
+    guard let body = response as? [String: Any],
+      let content = body["content"] as? [Any]
+    else {
+      return ""
+    }
+
+    let blocks = content.compactMap { $0 as? [String: Any] }
+
+    let toolCalls: [[String: Any]] = blocks.compactMap { block in
+      guard block["type"] as? String == "tool_use" else { return nil }
+      return [
+        "id": block["id"] as? String ?? "",
+        "name": block["name"] as? String ?? "",
+        "arguments": JSONSupport.toJSON(block["input"] ?? [String: Any]()),
+      ]
+    }
+    if !toolCalls.isEmpty { return toolCalls }
+
+    let text =
+      blocks
+      .compactMap { block -> String? in
+        guard block["type"] as? String == "text" else { return nil }
+        return block["text"] as? String
+      }
+      .joined()
+
+    return finalize(agent, text: text)
+  }
+
+  private static func finalize(_ agent: Agent, text: String) -> Any {
+    guard agent.hasStructuredOutputs, !text.isEmpty else { return text }
+    guard let parsed = JSONSupport.parse(json: text),
+      parsed is [String: Any] || parsed is [Any]
+    else {
+      return text
+    }
+    return parsed
+  }
+}

--- a/runtime/swift/prompty/Sources/PromptyAnthropic/AnthropicWire.swift
+++ b/runtime/swift/prompty/Sources/PromptyAnthropic/AnthropicWire.swift
@@ -1,0 +1,216 @@
+import Foundation
+
+/// Wire-format projection for the Anthropic Messages API.
+///
+/// Every function here mirrors the Rust reference implementation
+/// (`runtime/rust/prompty-anthropic/src/wire.rs`) so all runtimes produce
+/// identical request bodies for the shared `spec/vectors/wire` contract.
+import Prompty
+
+import PromptyModel
+
+public enum AnthropicWire {
+
+  /// Anthropic requires `max_tokens`; default when the prompt omits it.
+  public static let defaultMaxTokens = 4096
+
+  /// The `anthropic-version` header value every request must carry.
+  public static let anthropicVersion = "2023-06-01"
+
+  // MARK: - Request body
+
+  /// Build the request body for a Messages API call.
+  ///
+  /// System and developer messages collapse into a top-level `system` string;
+  /// every other message becomes a typed content-block array.
+  public static func chatArgs(_ agent: Agent, messages: [Message]) throws -> [String: Any] {
+    var body: [String: Any] = ["model": agent.modelId]
+
+    let system = extractSystem(messages)
+    if !system.isEmpty { body["system"] = system }
+
+    body["messages"] =
+      messages
+      .filter { $0.role != .system && $0.role != .developer }
+      .map(message)
+
+    applyOptions(&body, agent.modelOptions)
+
+    let tools = try (agent.tools ?? []).map(tool)
+    if !tools.isEmpty { body["tools"] = tools }
+
+    if let outputConfig = try outputConfig(agent) {
+      body["output_config"] = outputConfig
+    }
+    return body
+  }
+
+  // MARK: - System extraction
+
+  /// Join every system/developer message's text with `\n\n`.
+  static func extractSystem(_ messages: [Message]) -> String {
+    messages
+      .filter { $0.role == .system || $0.role == .developer }
+      .map(\.textContent)
+      .filter { !$0.isEmpty }
+      .joined(separator: "\n\n")
+  }
+
+  // MARK: - Messages
+
+  /// Project a message onto the Anthropic wire shape. Content is always a
+  /// typed block array.
+  public static func message(_ message: Message) -> [String: Any] {
+    let role = (message.role == .assistant) ? "assistant" : "user"
+
+    // Batched tool results (from the agent loop) pass through verbatim.
+    if let results = message.metadata["tool_results"] {
+      return ["role": role, "content": results]
+    }
+
+    // A single tool result becomes one `tool_result` block.
+    if let toolUseId = message.metadata["tool_use_id"] as? String {
+      return [
+        "role": role,
+        "content": [
+          [
+            "type": "tool_result",
+            "tool_use_id": toolUseId,
+            "content": message.textContent,
+          ]
+        ],
+      ]
+    }
+
+    // Raw assistant content blocks preserved from a prior response.
+    if let raw = message.metadata["content"] {
+      return ["role": role, "content": raw]
+    }
+
+    return ["role": role, "content": message.parts.map(part)]
+  }
+
+  /// Project a single content part onto its typed wire block.
+  public static func part(_ part: ContentPart) -> [String: Any] {
+    switch part {
+    case .textPart(let text):
+      return ["type": "text", "text": text.value]
+
+    case .imagePart(let image):
+      if image.source.hasPrefix("http://") || image.source.hasPrefix("https://") {
+        return ["type": "image", "source": ["type": "url", "url": image.source]]
+      }
+      return [
+        "type": "image",
+        "source": [
+          "type": "base64",
+          "media_type": image.mediaType ?? "image/png",
+          "data": image.source,
+        ],
+      ]
+
+    case .audioPart:
+      return ["type": "text", "text": "[audio content not supported by Anthropic]"]
+
+    case .filePart:
+      return ["type": "text", "text": "[file content not supported by Anthropic]"]
+    }
+  }
+
+  // MARK: - Options
+
+  static func applyOptions(_ body: inout [String: Any], _ options: ModelOptions?) {
+    var maxTokens = defaultMaxTokens
+
+    if let options {
+      if let wire = try? options.toWire("anthropic") {
+        for (key, value) in wire where !(value is NSNull) {
+          if key == "max_tokens" {
+            maxTokens = intValue(value) ?? defaultMaxTokens
+          } else {
+            body[key] = fixFloat(value)
+          }
+        }
+      }
+      if let extras = options.additionalProperties {
+        for (key, value) in extras where body[key] == nil {
+          body[key] = value
+        }
+      }
+    }
+
+    // `max_tokens` is always required by the Anthropic API.
+    body["max_tokens"] = maxTokens
+  }
+
+  static func intValue(_ value: Any) -> Int? {
+    switch value {
+    case let int as Int: return int
+    case let int as Int32: return Int(int)
+    case let double as Double: return Int(double)
+    case let float as Float: return Int(float)
+    case let number as NSNumber: return number.intValue
+    default: return nil
+    }
+  }
+
+  /// `ModelOptions` stores fractional values as `Float`; round-trip through the
+  /// shortest `Float` literal so JSON serialization avoids binary artifacts.
+  static func fixFloat(_ value: Any) -> Any {
+    guard let float = value as? Float else { return value }
+    return Double(String(float)) ?? Double(float)
+  }
+
+  // MARK: - Tools
+
+  static func tool(_ tool: Tool) throws -> [String: Any] {
+    var wire: [String: Any] = ["name": tool.name]
+    if let description = tool.toolDescription { wire["description"] = description }
+
+    if tool.kindName == "function" {
+      let bound = tool.boundParameterNames
+      let visible = tool.functionParameters.filter { !bound.contains($0.name) }
+      wire["input_schema"] = try JSONSchema.parameters(visible, strict: false)
+    } else {
+      wire["input_schema"] = ["type": "object", "properties": [String: Any]()]
+    }
+    return wire
+  }
+
+  // MARK: - Structured output
+
+  static func outputConfig(_ agent: Agent) throws -> [String: Any]? {
+    guard let schema = try Structured.outputSchema(agent) else { return nil }
+    return ["format": ["type": "json_schema", "schema": schema]]
+  }
+
+  // MARK: - Agent loop
+
+  /// Format tool results back into conversation messages.
+  ///
+  /// Produces one assistant message carrying the response's original content
+  /// blocks, then one user message batching every `tool_result` block.
+  public static func toolMessages(
+    rawResponse: Any, calls: [ToolCall], results: [String]
+  ) -> [Message] {
+    var messages: [Message] = []
+
+    let contentBlocks = (rawResponse as? [String: Any])?["content"] ?? [Any]()
+    var assistant = Message.withText(.assistant, "")
+    assistant.metadata = ["content": contentBlocks]
+    messages.append(assistant)
+
+    let resultBlocks: [Any] = zip(calls, results).map { call, result in
+      [
+        "type": "tool_result",
+        "tool_use_id": call.id,
+        "content": result,
+      ]
+    }
+    var user = Message.withText(.user, "")
+    user.metadata = ["tool_results": resultBlocks]
+    messages.append(user)
+
+    return messages
+  }
+}

--- a/runtime/swift/prompty/Sources/PromptyAnthropic/Registration.swift
+++ b/runtime/swift/prompty/Sources/PromptyAnthropic/Registration.swift
@@ -1,0 +1,19 @@
+import Foundation
+
+/// Registers the Anthropic executor and processor.
+///
+/// Call once during host startup:
+///
+/// ```swift
+/// import PromptyAnthropic
+///
+/// registerAnthropic()
+/// ```
+import Prompty
+
+import PromptyModel
+
+public func registerAnthropic(into registry: Registry = .shared) {
+  registry.register(executor: AnthropicExecutor(), for: "anthropic")
+  registry.register(processor: AnthropicProcessor(), for: "anthropic")
+}

--- a/runtime/swift/prompty/Sources/PromptyFoundry/FoundryModels.swift
+++ b/runtime/swift/prompty/Sources/PromptyFoundry/FoundryModels.swift
@@ -1,0 +1,85 @@
+/// Foundry/Azure model discovery: map raw catalog and deployment entries to
+/// `ModelInfo`.
+///
+/// Foundry project connections list *deployments* (the invokable ids), while
+/// Azure OpenAI key connections list the lower-level *model catalog*. Both raw
+/// shapes map into the provider-neutral `ModelInfo` contract, then are enriched
+/// from the shared dataset (a no-op today — the dataset has no foundry entries).
+/// This mirrors `runtime/rust/prompty-foundry/src/models.rs`.
+import Foundation
+import Prompty
+import PromptyModel
+
+public enum FoundryModels {
+
+  /// Map one Azure OpenAI model-catalog entry into `ModelInfo`.
+  public static func modelInfo(fromCatalog raw: Any) -> ModelInfo {
+    let object = raw as? [String: Any] ?? [:]
+    var info = ModelInfo()
+    info.id = object["id"] as? String ?? ""
+    info.ownedBy = object["owned_by"] as? String
+    if let window = int32(object, ["maxContextLength"]) {
+      info.contextWindow = window
+    }
+    info.additionalProperties = object
+    Discovery.enrich(provider: "foundry", info: &info)
+    return info
+  }
+
+  /// Map one Foundry deployment entry into `ModelInfo`. Handles both the flat
+  /// data-plane shape (`modelName`, `modelPublisher`, top-level `capabilities`)
+  /// and the nested ARM management-plane shape (`properties.model`).
+  public static func modelInfo(fromDeployment raw: Any) -> ModelInfo {
+    let object = raw as? [String: Any] ?? [:]
+    let properties = object["properties"] as? [String: Any] ?? [:]
+    let model = properties["model"] as? [String: Any] ?? [:]
+    let capabilities =
+      (properties["capabilities"] as? [String: Any])
+      ?? (model["capabilities"] as? [String: Any])
+      ?? (object["capabilities"] as? [String: Any])
+      ?? [:]
+
+    var info = ModelInfo()
+    info.id = object["name"] as? String ?? ""
+    info.displayName = (object["modelName"] as? String) ?? (model["name"] as? String)
+    info.ownedBy =
+      (object["modelPublisher"] as? String) ?? (model["publisher"] as? String) ?? "azure"
+    info.contextWindow =
+      int32(capabilities, ["maxContextLength", "contextWindow", "context_length"])
+      ?? int32(model, ["maxContextLength"])
+      ?? int32(object, ["maxContextLength"])
+    info.inputModalities = stringVec(
+      capabilities, ["inputModalities", "input_modalities", "supportedInputModalities"])
+    info.outputModalities = stringVec(
+      capabilities, ["outputModalities", "output_modalities", "supportedOutputModalities"])
+    info.additionalProperties = object
+    Discovery.enrich(provider: "foundry", info: &info)
+    return info
+  }
+
+  /// Read the first key that holds an integer, accepting numeric strings too.
+  private static func int32(_ object: [String: Any], _ keys: [String]) -> Int32? {
+    for key in keys {
+      guard let value = object[key] else { continue }
+      if let number = value as? NSNumber { return number.int32Value }
+      if let text = value as? String, let parsed = Int32(text) { return parsed }
+    }
+    return nil
+  }
+
+  /// Read the first key that holds a string list, accepting a comma-separated
+  /// string too.
+  private static func stringVec(_ object: [String: Any], _ keys: [String]) -> [String]? {
+    for key in keys {
+      guard let value = object[key] else { continue }
+      if let array = value as? [Any] {
+        return array.compactMap { $0 as? String }
+      }
+      if let text = value as? String {
+        return text.split(separator: ",").map { $0.trimmingCharacters(in: .whitespaces) }
+          .filter { !$0.isEmpty }
+      }
+    }
+    return nil
+  }
+}

--- a/runtime/swift/prompty/Sources/PromptyOpenAI/OpenAIModels.swift
+++ b/runtime/swift/prompty/Sources/PromptyOpenAI/OpenAIModels.swift
@@ -1,0 +1,22 @@
+/// OpenAI model discovery: map a raw `/v1/models` entry to `ModelInfo`.
+///
+/// OpenAI reports only `id` and `owned_by`, so the mapped result is enriched
+/// from the shared capability dataset (`Discovery.enrich`). The full raw entry
+/// is preserved under `additionalProperties`.
+import Foundation
+import Prompty
+import PromptyModel
+
+public enum OpenAIModels {
+
+  /// Convert a raw OpenAI model object into an enriched `ModelInfo`.
+  public static func modelInfo(fromWire raw: Any) -> ModelInfo {
+    let object = raw as? [String: Any] ?? [:]
+    var info = ModelInfo()
+    info.id = object["id"] as? String ?? ""
+    info.ownedBy = object["owned_by"] as? String
+    info.additionalProperties = object
+    Discovery.enrich(provider: "openai", info: &info)
+    return info
+  }
+}

--- a/runtime/swift/prompty/Tests/PromptyTests/AgentVectorTests.swift
+++ b/runtime/swift/prompty/Tests/PromptyTests/AgentVectorTests.swift
@@ -1,0 +1,382 @@
+import Foundation
+
+import PromptyModel
+
+import XCTest
+
+/// Agent-stage conformance — drives the agent loop (`turn()`) against the
+/// generated `agent` vectors.
+///
+/// Each vector supplies a `sequence` of canned LLM responses and the expected
+/// final result (or error). A `MockExecutor` replays the canned responses by
+/// call index; a `MockProcessor` projects each response into either the
+/// processor's tool-call array or a content string. Tool handlers return the
+/// vector's canned `tool_results`.
+///
+/// This mirrors the Rust reference harness (`tests/agent_vectors.rs`) so the
+/// two runtimes are validated identically. The assertion contract matches the
+/// Python reference: basic vectors assert only the final `result` (plus, for
+/// bindings, the arguments the tool was invoked with); error vectors assert the
+/// thrown message.
+@testable import Prompty
+
+final class AgentVectorTests: XCTestCase {
+
+  // MARK: - Mock executor
+
+  /// Replays canned LLM responses in order, ignoring the live messages.
+  ///
+  /// The loop's job under test is control flow, not prompt construction, so the
+  /// executor answers purely from the vector's `sequence`.
+  private final class MockExecutor: Executor {
+    private let responses: [Any]
+    private var index = 0
+
+    init(responses: [Any]) {
+      self.responses = responses
+    }
+
+    func execute(agent: Agent, messages: [Message]) async throws -> Any {
+      defer { index += 1 }
+      guard index < responses.count else {
+        throw Prompty.InvokerError.execution(
+          "MockExecutor: no more responses (requested index \(index))")
+      }
+      return responses[index]
+    }
+
+    /// Format the tool turn the loop appends between iterations.
+    ///
+    /// The mock executor ignores messages when replaying, so this only has to
+    /// keep the conversation well-formed; the assistant tool-call metadata plus
+    /// one `tool` message per result mirrors the OpenAI wire shape.
+    func formatToolMessages(
+      rawResponse: Any, toolCalls: [ToolCall], toolResults: [String], textContent: String?
+    ) throws -> [Message] {
+      var messages: [Message] = []
+
+      let wireCalls: [Any] = toolCalls.map { call in
+        [
+          "id": call.id,
+          "type": "function",
+          "function": ["name": call.name, "arguments": call.arguments],
+        ]
+      }
+      var assistant = Message.withText(.assistant, textContent ?? "")
+      assistant.metadata = ["tool_calls": wireCalls]
+      messages.append(assistant)
+
+      for (call, result) in zip(toolCalls, toolResults) {
+        messages.append(Message.toolResult(toolCallId: call.id, result: result))
+      }
+      return messages
+    }
+  }
+
+  // MARK: - Mock processor
+
+  /// Projects an OpenAI-style response into the loop's expected shape.
+  ///
+  /// A message carrying non-empty `tool_calls` becomes the `{ id, name,
+  /// arguments }` array the pipeline reads tool calls from; otherwise the
+  /// message content becomes the final string result.
+  private struct MockProcessor: Processor {
+    func process(agent: Agent, response: Any) async throws -> Any {
+      guard let dict = response as? [String: Any],
+        let choices = dict["choices"] as? [Any],
+        let first = choices.first as? [String: Any],
+        let message = first["message"] as? [String: Any]
+      else {
+        return ""
+      }
+
+      if let toolCalls = message["tool_calls"] as? [Any], !toolCalls.isEmpty {
+        let calls: [Any] = toolCalls.compactMap { entry -> [String: Any]? in
+          guard let call = entry as? [String: Any],
+            let function = call["function"] as? [String: Any]
+          else { return nil }
+          return [
+            "id": call["id"] as? String ?? "",
+            "name": function["name"] as? String ?? "",
+            "arguments": function["arguments"] as? String ?? "",
+          ]
+        }
+        return calls
+      }
+
+      return message["content"] as? String ?? ""
+    }
+  }
+
+  // MARK: - Harness
+
+  /// One vector's worth of setup: a mock provider registered under a unique
+  /// key, an agent whose instructions reproduce the input messages, and tool
+  /// handlers backed by the vector's canned results.
+  private struct Harness {
+    let agent: Agent
+    let tools: [String: ToolHandler]
+    let registry: Registry
+    let expected: [String: Any]
+    let inputs: [String: Any]
+    /// Arguments captured per tool name, for binding assertions.
+    let captured: CapturedArguments
+  }
+
+  /// Thread-safe capture of the arguments each tool was invoked with.
+  private final class CapturedArguments: @unchecked Sendable {
+    private let lock = NSLock()
+    private var storage: [String: [String: Any]] = [:]
+
+    func record(_ name: String, _ arguments: [String: Any]) {
+      lock.lock()
+      defer { lock.unlock() }
+      storage[name] = arguments
+    }
+
+    func arguments(for name: String) -> [String: Any]? {
+      lock.lock()
+      defer { lock.unlock() }
+      return storage[name]
+    }
+  }
+
+  /// Per-tool queue of canned results, popped in call order.
+  private final class ResultQueue: @unchecked Sendable {
+    private let lock = NSLock()
+    private var results: [String]
+    private var index = 0
+    private let name: String
+
+    init(name: String, results: [String]) {
+      self.name = name
+      self.results = results
+    }
+
+    func next() -> String {
+      lock.lock()
+      defer { lock.unlock() }
+      defer { index += 1 }
+      guard index < results.count else { return "(mock result #\(index) for \(name))" }
+      return results[index]
+    }
+  }
+
+  private func vector(_ name: String) throws -> [String: Any] {
+    let all = try Spec.vectors("agent")
+    guard let match = all.first(where: { ($0["name"] as? String) == name }) else {
+      throw VectorFailure("agent vector '\(name)' not found")
+    }
+    return match
+  }
+
+  /// Build the harness for a named vector.
+  ///
+  /// `extraResponses` and `toolOverride` let error-case tests append a trailing
+  /// response or restrict which tools are registered.
+  private func harness(
+    for name: String,
+    extraResponses: [Any] = [],
+    toolOverride: [String]? = nil
+  ) throws -> Harness {
+    let vector = try vector(name)
+    let input = vector["input"] as? [String: Any] ?? [:]
+    let sequence = vector["sequence"] as? [Any] ?? []
+    let expected = vector["expected"] as? [String: Any] ?? [:]
+
+    // A private registry keeps parallel vectors from colliding on provider key.
+    let registry = Registry()
+    registry.registerDefaults()
+    let providerKey = "specmock_\(name)"
+
+    var responses: [Any] = sequence.compactMap { step in
+      (step as? [String: Any])?["llm_response"]
+    }
+    responses.append(contentsOf: extraResponses)
+
+    registry.register(executor: MockExecutor(responses: responses), for: providerKey)
+    registry.register(processor: MockProcessor(), for: providerKey)
+
+    // Re-encode the input messages back into instructions, so `prepare`
+    // reproduces them — matching the Rust reference harness.
+    let messages = input["messages"] as? [Any] ?? []
+    let instructionBlocks = messages.compactMap { entry -> String? in
+      guard let message = entry as? [String: Any] else { return nil }
+      let role = message["role"] as? String ?? "user"
+      let content = message["content"] as? String ?? ""
+      return "\(role):\n\(content)"
+    }
+
+    var data: [String: Any] = [
+      "kind": "prompt",
+      "name": "agent_test_\(name)",
+      "model": ["id": "gpt-4", "provider": providerKey],
+      "instructions": instructionBlocks.joined(separator: "\n\n"),
+      "template": [
+        "format": ["kind": "jinja2"],
+        "parser": ["kind": "prompty"],
+      ],
+    ]
+    if let tools = input["tools"] { data["tools"] = tools }
+    let agent = try Agent.load(data)
+
+    let inputs = input["parent_inputs"] as? [String: Any] ?? [:]
+    let captured = CapturedArguments()
+    let tools = buildToolHandlers(
+      vector: vector, input: input, override: toolOverride, captured: captured)
+
+    return Harness(
+      agent: agent, tools: tools, registry: registry,
+      expected: expected, inputs: inputs, captured: captured)
+  }
+
+  /// Build canned tool handlers keyed by tool name.
+  ///
+  /// Results across the whole sequence are queued per tool, mapped from each
+  /// `tool_results` entry through the step's `expected_tool_calls` (id → name).
+  /// Tools named only in `tool_functions` still get an empty queue so they are
+  /// registered.
+  private func buildToolHandlers(
+    vector: [String: Any],
+    input: [String: Any],
+    override: [String]?,
+    captured: CapturedArguments
+  ) -> [String: ToolHandler] {
+    var queues: [String: [String]] = [:]
+
+    if let sequence = vector["sequence"] as? [Any] {
+      for entry in sequence {
+        guard let step = entry as? [String: Any] else { continue }
+        let expectedCalls = step["expected_tool_calls"] as? [Any] ?? []
+        let results = step["tool_results"] as? [Any] ?? []
+        for resultEntry in results {
+          guard let result = resultEntry as? [String: Any] else { continue }
+          let callId = result["tool_call_id"] as? String ?? ""
+          let text = result["result"] as? String ?? ""
+          let name =
+            expectedCalls.compactMap { $0 as? [String: Any] }
+            .first(where: { ($0["id"] as? String) == callId })?["name"] as? String ?? "unknown"
+          queues[name, default: []].append(text)
+        }
+      }
+    }
+
+    if let toolFunctions = input["tool_functions"] as? [String: Any] {
+      for name in toolFunctions.keys where queues[name] == nil {
+        queues[name] = []
+      }
+    }
+
+    let allowed = override.map(Set.init)
+    var handlers: [String: ToolHandler] = [:]
+    for (name, results) in queues {
+      if let allowed, !allowed.contains(name) { continue }
+      let queue = ResultQueue(name: name, results: results)
+      handlers[name] = .sync { arguments in
+        captured.record(name, arguments)
+        return queue.next()
+      }
+    }
+    return handlers
+  }
+
+  private func runResult(_ name: String) async throws -> Any? {
+    let harness = try harness(for: name)
+    return try await Pipeline.turn(
+      harness.agent, inputs: harness.inputs, tools: harness.tools, registry: harness.registry)
+  }
+
+  private func expectedResult(_ harness: Harness) throws -> String {
+    try XCTUnwrap(harness.expected["result"] as? String)
+  }
+
+  // MARK: - Basic vectors
+
+  func testBasicAgentVectors() async throws {
+    var run = VectorRun(stage: "agent")
+    let names = [
+      "no_tool_calls",
+      "single_tool_call",
+      "multiple_tool_calls_single_turn",
+      "multi_turn_tool_calls",
+      "tool_result_message_format",
+      "assistant_tool_calls_metadata",
+      "empty_tool_result",
+      "async_tool_function",
+    ]
+
+    for name in names {
+      await run.checkAsync(name) {
+        let harness = try self.harness(for: name)
+        let result = try await Pipeline.turn(
+          harness.agent, inputs: harness.inputs, tools: harness.tools,
+          registry: harness.registry)
+        let expected = try XCTUnwrap(harness.expected["result"] as? String)
+        try expectEqual(result, expected, "result")
+      }
+    }
+
+    run.assertClean()
+  }
+
+  func testAsyncToolFunctionUsesAsyncHandler() async throws {
+    // async_tool_function's handler is defined async; drive it through the
+    // async ToolHandler shape explicitly to prove that path executes.
+    let harness = try harness(for: "async_tool_function")
+    var tools = harness.tools
+    tools["lookup"] = .async { _ in "found: test data" }
+
+    let result = try await Pipeline.turn(
+      harness.agent, inputs: harness.inputs, tools: tools, registry: harness.registry)
+    try expectEqual(result, "I found: test data", "result")
+  }
+
+  // MARK: - Bindings
+
+  func testBindingsInjectedIntoToolArguments() async throws {
+    let harness = try harness(for: "bindings_injected")
+
+    let result = try await Pipeline.turn(
+      harness.agent, inputs: harness.inputs, tools: harness.tools, registry: harness.registry)
+    try expectEqual(result, try expectedResult(harness), "result")
+
+    // The binding must resolve `preferred_unit` from parent inputs and inject
+    // it into the tool arguments, overriding whatever the model supplied.
+    let step = try XCTUnwrap((try vector("bindings_injected")["sequence"] as? [Any])?.first)
+    let expectedArgs = try XCTUnwrap(
+      ((step as? [String: Any])?["expected_execution_args"] as? [String: Any])?["get_weather"]
+        as? [String: Any])
+    let actualArgs = try XCTUnwrap(harness.captured.arguments(for: "get_weather"))
+    try expectEqual(actualArgs, expectedArgs, "get_weather execution args")
+  }
+
+  // MARK: - Error cases
+
+  func testMaxIterationsExceeded() async throws {
+    do {
+      _ = try await runResult("max_iterations_exceeded")
+      XCTFail("expected max_iterations_exceeded to throw")
+    } catch let error as Prompty.InvokerError {
+      let message = String(describing: error)
+      XCTAssertTrue(
+        message.contains("exceeded") && message.contains("iterations"),
+        "expected an iteration-limit error, got: \(message)")
+    }
+  }
+
+  func testToolNotRegisteredThrows() async throws {
+    // Only get_weather is registered; the vector's response calls unknown_tool.
+    let harness = try harness(for: "tool_not_registered_error", toolOverride: ["get_weather"])
+    do {
+      _ = try await Pipeline.turn(
+        harness.agent, inputs: harness.inputs, tools: harness.tools,
+        registry: harness.registry)
+      XCTFail("expected tool_not_registered_error to throw")
+    } catch let error as Prompty.InvokerError {
+      let message = String(describing: error)
+      XCTAssertTrue(
+        message.contains("Tool not registered"),
+        "expected a missing-tool error, got: \(message)")
+    }
+  }
+}

--- a/runtime/swift/prompty/Tests/PromptyTests/AgentVectorTests.swift
+++ b/runtime/swift/prompty/Tests/PromptyTests/AgentVectorTests.swift
@@ -292,20 +292,22 @@ final class AgentVectorTests: XCTestCase {
 
   // MARK: - Basic vectors
 
+  /// Basic control-flow vectors driven purely by their final `result`.
+  private static let basicRunVectors = [
+    "no_tool_calls",
+    "single_tool_call",
+    "multiple_tool_calls_single_turn",
+    "multi_turn_tool_calls",
+    "tool_result_message_format",
+    "assistant_tool_calls_metadata",
+    "empty_tool_result",
+    "async_tool_function",
+  ]
+
   func testBasicAgentVectors() async throws {
     var run = VectorRun(stage: "agent")
-    let names = [
-      "no_tool_calls",
-      "single_tool_call",
-      "multiple_tool_calls_single_turn",
-      "multi_turn_tool_calls",
-      "tool_result_message_format",
-      "assistant_tool_calls_metadata",
-      "empty_tool_result",
-      "async_tool_function",
-    ]
 
-    for name in names {
+    for name in Self.basicRunVectors {
       await run.checkAsync(name) {
         let harness = try self.harness(for: name)
         let result = try await Pipeline.turn(
@@ -522,24 +524,27 @@ final class AgentVectorTests: XCTestCase {
 
   // MARK: - Extension vectors — result cases
 
+  /// Extension vectors asserted by final `result` (plus denied/executed tools
+  /// and, when the vector carries `on_event`, an event-subset check).
+  private static let extensionResultVectors = [
+    "context_trim_basic",
+    "context_no_trim_when_fits",
+    "context_preserves_system_messages",
+    "guardrail_tool_deny",
+    "guardrail_all_pass",
+    "steering_inject_message",
+    "steering_multiple_messages",
+    "parallel_tools_basic",
+    "parallel_tools_with_guardrail_deny",
+    "events_basic_tool_loop",
+    "events_no_tools",
+    "events_error_logged",
+  ]
+
   func testExtensionResultVectors() async throws {
     var run = VectorRun(stage: "agent")
-    let names = [
-      "context_trim_basic",
-      "context_no_trim_when_fits",
-      "context_preserves_system_messages",
-      "guardrail_tool_deny",
-      "guardrail_all_pass",
-      "steering_inject_message",
-      "steering_multiple_messages",
-      "parallel_tools_basic",
-      "parallel_tools_with_guardrail_deny",
-      "events_basic_tool_loop",
-      "events_no_tools",
-      "events_error_logged",
-    ]
 
-    for name in names {
+    for name in Self.extensionResultVectors {
       await run.checkAsync(name) {
         let harness = try self.harness(for: name)
         let input = try self.vector(name)["input"] as? [String: Any] ?? [:]
@@ -619,10 +624,17 @@ final class AgentVectorTests: XCTestCase {
 
   // MARK: - Extension vectors — cancellation cases
 
+  /// Cancellation vectors, asserted by a thrown `CancelledError` plus events.
+  private static let cancellationVectors = [
+    "cancellation_before_llm",
+    "cancellation_between_iterations",
+    "cancellation_between_tools",
+  ]
+
   func testCancellationVectors() async throws {
     // before_llm cancels up front; the between_* vectors trip the token from the
     // first tool call and rely on the loop's cancel checks to stop the turn.
-    for name in ["cancellation_before_llm", "cancellation_between_iterations", "cancellation_between_tools"] {
+    for name in Self.cancellationVectors {
       let harness = try harness(for: name)
       let input = try vector(name)["input"] as? [String: Any] ?? [:]
       let cancelSpec = input["cancel"] as? [String: Any] ?? [:]
@@ -652,5 +664,45 @@ final class AgentVectorTests: XCTestCase {
         }
       }
     }
+  }
+
+  // MARK: - Coverage completeness
+
+  /// Every agent vector this suite drives, across all test methods.
+  ///
+  /// Kept in one place so the guard below and the per-method loops share a
+  /// single source of truth — a name can't be run without also being counted,
+  /// and vice versa.
+  private static let coveredVectors: Set<String> =
+    Set(basicRunVectors)
+    .union(extensionResultVectors)
+    .union(cancellationVectors)
+    .union([
+      // Singletons exercised by their own dedicated test methods.
+      "bindings_injected",
+      "max_iterations_exceeded",
+      "tool_not_registered_error",
+      "guardrail_input_deny",
+      "guardrail_output_deny",
+    ])
+
+  /// Fail loudly if the generated `agent` stage grows a vector this suite does
+  /// not run. Typra will eventually enforce runtime/vector parity from the
+  /// generation side; until then this is the runtime-side backstop, so a newly
+  /// generated agent vector cannot land silently unexercised.
+  func testEveryAgentVectorIsCovered() throws {
+    let generated = Set(try Spec.vectors("agent").compactMap { $0["name"] as? String })
+
+    let unwired = generated.subtracting(Self.coveredVectors)
+    XCTAssertTrue(
+      unwired.isEmpty,
+      "agent vectors present in the generated file but not exercised by this suite: "
+        + "\(unwired.sorted()). Wire them into the matching test method.")
+
+    let stale = Self.coveredVectors.subtracting(generated)
+    XCTAssertTrue(
+      stale.isEmpty,
+      "this suite references agent vectors that no longer exist in the generated file: "
+        + "\(stale.sorted()). Remove them.")
   }
 }

--- a/runtime/swift/prompty/Tests/PromptyTests/AgentVectorTests.swift
+++ b/runtime/swift/prompty/Tests/PromptyTests/AgentVectorTests.swift
@@ -379,4 +379,278 @@ final class AgentVectorTests: XCTestCase {
         "expected a missing-tool error, got: \(message)")
     }
   }
+
+  // MARK: - Extension support
+
+  /// Thread-safe recorder for the events a vector's `on_event` sink emits.
+  private final class EventRecorder: @unchecked Sendable {
+    private let lock = NSLock()
+    private var events: [AgentEvent] = []
+
+    func record(_ event: AgentEvent) {
+      lock.lock()
+      defer { lock.unlock() }
+      events.append(event)
+    }
+
+    /// Event type strings in emission order.
+    var types: [String] {
+      lock.lock()
+      defer { lock.unlock() }
+      return events.map(\.type)
+    }
+  }
+
+  /// A once-only latch: the first `trip()` returns true, all later ones false.
+  private final class FirstCallLatch: @unchecked Sendable {
+    private let lock = NSLock()
+    private var tripped = false
+
+    func trip() -> Bool {
+      lock.lock()
+      defer { lock.unlock() }
+      if tripped { return false }
+      tripped = true
+      return true
+    }
+  }
+
+  /// Build the agent-loop options a vector's `input` extension keys describe.
+  ///
+  /// Reads `context_budget`, `guardrails`, `steering`, `parallel_tool_calls`,
+  /// and wires the recorder when `on_event` is present. Cancellation is wired by
+  /// the caller (it owns the token), so it is passed in.
+  private func makeOptions(
+    input: [String: Any],
+    recorder: EventRecorder?,
+    cancel: CancellationToken?
+  ) -> Pipeline.Options {
+    var options = Pipeline.Options()
+
+    if let recorder {
+      options.onEvent = { event in recorder.record(event) }
+    }
+    if let budget = input["context_budget"] as? Int {
+      options.contextBudget = budget
+    }
+    if let parallel = input["parallel_tool_calls"] as? Bool {
+      options.parallelToolCalls = parallel
+    }
+    options.cancel = cancel
+    options.guardrails = makeGuardrails(input["guardrails"] as? [String: Any])
+    options.steering = makeSteering(input["steering"] as? [String: Any])
+
+    return options
+  }
+
+  /// Translate a vector's `guardrails` block into runtime guardrail closures.
+  private func makeGuardrails(_ spec: [String: Any]?) -> Guardrails? {
+    guard let spec else { return nil }
+    var guardrails = Guardrails()
+
+    if let input = spec["input"] as? [String: Any] {
+      let deny = (input["action"] as? String) == "deny"
+      let reason = input["reason"] as? String ?? "Input denied"
+      guardrails.input = { _ in deny ? .deny(reason) : .allow() }
+    }
+    if let output = spec["output"] as? [String: Any] {
+      let deny = (output["action"] as? String) == "deny"
+      let reason = output["reason"] as? String ?? "Output denied"
+      guardrails.output = { _ in deny ? .deny(reason) : .allow() }
+    }
+    if let tool = spec["tool"] as? [String: Any] {
+      let denied = Set((tool["deny_tools"] as? [Any] ?? []).compactMap { $0 as? String })
+      let reason = tool["reason"] as? String ?? "Tool denied"
+      guardrails.tool = { name, _ in denied.contains(name) ? .deny(reason) : .allow() }
+    }
+    return guardrails
+  }
+
+  /// Translate a vector's `steering` block into a runtime steering queue.
+  private func makeSteering(_ spec: [String: Any]?) -> Steering? {
+    guard let spec, let messages = spec["messages"] as? [Any] else { return nil }
+    let scheduled = messages.compactMap { entry -> SteeringMessage? in
+      guard let message = entry as? [String: Any] else { return nil }
+      return SteeringMessage(
+        injectBeforeIteration: message["inject_before_iteration"] as? Int ?? 1,
+        role: message["role"] as? String ?? "user",
+        text: message["text"] as? String ?? "")
+    }
+    return Steering(scheduled)
+  }
+
+  /// Wrap every handler so the first tool call trips the shared latch, cancelling
+  /// the token — the mechanism the `cancellation_between_*` vectors rely on.
+  private func cancelOnFirstTool(
+    _ tools: [String: ToolHandler],
+    token: CancellationToken,
+    reason: String
+  ) -> [String: ToolHandler] {
+    let latch = FirstCallLatch()
+    var wrapped: [String: ToolHandler] = [:]
+    for (name, handler) in tools {
+      wrapped[name] = .async { arguments in
+        let result = try await handler.invoke(arguments)
+        if latch.trip() { token.cancel(reason: reason) }
+        return result
+      }
+    }
+    return wrapped
+  }
+
+  /// Assert the recorded events satisfy the vector's lenient event contract:
+  /// every expected type (minus `status`) is present — with `tool_result` and
+  /// `error` interchangeable — and a terminal `done`/`cancelled` event fired.
+  private func assertEvents(_ recorder: EventRecorder, expected: [[String: Any]], _ label: String) {
+    let actual = Set(recorder.types)
+    let expectedTypes = Set(expected.compactMap { $0["type"] as? String }).subtracting(["status"])
+
+    func satisfied(_ type: String) -> Bool {
+      if actual.contains(type) { return true }
+      if type == "error" && actual.contains("tool_result") { return true }
+      if type == "tool_result" && actual.contains("error") { return true }
+      return false
+    }
+
+    for type in expectedTypes {
+      XCTAssertTrue(satisfied(type), "\(label): missing event '\(type)' in \(recorder.types)")
+    }
+    XCTAssertTrue(
+      actual.contains("done") || actual.contains("cancelled"),
+      "\(label): no terminal event in \(recorder.types)")
+  }
+
+  // MARK: - Extension vectors — result cases
+
+  func testExtensionResultVectors() async throws {
+    var run = VectorRun(stage: "agent")
+    let names = [
+      "context_trim_basic",
+      "context_no_trim_when_fits",
+      "context_preserves_system_messages",
+      "guardrail_tool_deny",
+      "guardrail_all_pass",
+      "steering_inject_message",
+      "steering_multiple_messages",
+      "parallel_tools_basic",
+      "parallel_tools_with_guardrail_deny",
+      "events_basic_tool_loop",
+      "events_no_tools",
+      "events_error_logged",
+    ]
+
+    for name in names {
+      await run.checkAsync(name) {
+        let harness = try self.harness(for: name)
+        let input = try self.vector(name)["input"] as? [String: Any] ?? [:]
+        let hasEvents = input["on_event"] != nil
+        let recorder = hasEvents ? EventRecorder() : nil
+        let options = self.makeOptions(input: input, recorder: recorder, cancel: nil)
+
+        let result = try await Pipeline.turn(
+          harness.agent, inputs: harness.inputs, tools: harness.tools,
+          registry: harness.registry, options: options)
+
+        let expected = try XCTUnwrap(harness.expected["result"] as? String)
+        try expectEqual(result, expected, "result")
+
+        // Denied tools must never have executed.
+        if let denied = harness.expected["denied_tools"] as? [Any] {
+          for entry in denied {
+            let tool = entry as? String ?? ""
+            XCTAssertNil(
+              harness.captured.arguments(for: tool),
+              "\(name): denied tool '\(tool)' should not have executed")
+          }
+        }
+        // Named tools must have executed, in any order.
+        if let order = harness.expected["tool_execution_order"] as? [Any] {
+          for entry in order {
+            let tool = entry as? String ?? ""
+            XCTAssertNotNil(
+              harness.captured.arguments(for: tool),
+              "\(name): tool '\(tool)' should have executed")
+          }
+        }
+        if let recorder, let events = harness.expected["events"] as? [[String: Any]] {
+          self.assertEvents(recorder, expected: events, name)
+        }
+      }
+    }
+
+    run.assertClean()
+  }
+
+  // MARK: - Extension vectors — guardrail error cases
+
+  func testGuardrailInputDenyThrows() async throws {
+    let harness = try harness(for: "guardrail_input_deny")
+    let input = try vector("guardrail_input_deny")["input"] as? [String: Any] ?? [:]
+    let options = makeOptions(input: input, recorder: nil, cancel: nil)
+    do {
+      _ = try await Pipeline.turn(
+        harness.agent, inputs: harness.inputs, tools: harness.tools,
+        registry: harness.registry, options: options)
+      XCTFail("expected guardrail_input_deny to throw")
+    } catch let error as GuardrailError {
+      let reason = try XCTUnwrap(harness.expected["error_reason"] as? String)
+      XCTAssertTrue(
+        error.description.contains(reason),
+        "expected reason '\(reason)', got: \(error.description)")
+    }
+  }
+
+  func testGuardrailOutputDenyThrows() async throws {
+    let harness = try harness(for: "guardrail_output_deny")
+    let input = try vector("guardrail_output_deny")["input"] as? [String: Any] ?? [:]
+    let options = makeOptions(input: input, recorder: nil, cancel: nil)
+    do {
+      _ = try await Pipeline.turn(
+        harness.agent, inputs: harness.inputs, tools: harness.tools,
+        registry: harness.registry, options: options)
+      XCTFail("expected guardrail_output_deny to throw")
+    } catch let error as GuardrailError {
+      let reason = try XCTUnwrap(harness.expected["error_reason"] as? String)
+      XCTAssertTrue(
+        error.description.contains(reason),
+        "expected reason '\(reason)', got: \(error.description)")
+    }
+  }
+
+  // MARK: - Extension vectors — cancellation cases
+
+  func testCancellationVectors() async throws {
+    // before_llm cancels up front; the between_* vectors trip the token from the
+    // first tool call and rely on the loop's cancel checks to stop the turn.
+    for name in ["cancellation_before_llm", "cancellation_between_iterations", "cancellation_between_tools"] {
+      let harness = try harness(for: name)
+      let input = try vector(name)["input"] as? [String: Any] ?? [:]
+      let cancelSpec = input["cancel"] as? [String: Any] ?? [:]
+      let cancelledAt = cancelSpec["cancelled_at"] as? String ?? ""
+
+      let token = CancellationToken()
+      var tools = harness.tools
+      if cancelledAt == "before_first_iteration" || cancelledAt.contains("before_iteration_1")
+        || name == "cancellation_before_llm"
+      {
+        token.cancel(reason: "Cancellation requested before first iteration")
+      } else {
+        tools = cancelOnFirstTool(tools, token: token, reason: "Cancellation requested after \(cancelledAt)")
+      }
+
+      let recorder = EventRecorder()
+      let options = makeOptions(input: input, recorder: recorder, cancel: token)
+
+      do {
+        _ = try await Pipeline.turn(
+          harness.agent, inputs: harness.inputs, tools: tools,
+          registry: harness.registry, options: options)
+        XCTFail("\(name): expected cancellation to throw")
+      } catch is CancelledError {
+        if let events = harness.expected["events"] as? [[String: Any]] {
+          assertEvents(recorder, expected: events, name)
+        }
+      }
+    }
+  }
 }

--- a/runtime/swift/prompty/Tests/PromptyTests/AnthropicProcessVectorTests.swift
+++ b/runtime/swift/prompty/Tests/PromptyTests/AnthropicProcessVectorTests.swift
@@ -1,0 +1,63 @@
+import Foundation
+
+import PromptyModel
+
+import XCTest
+
+@testable import Prompty
+
+/// Conformance against the Anthropic `process` cases in `vectors.json`.
+///
+/// Drives the real ``AnthropicProcessor``, including the structured-output
+/// finalization path that only engages when the agent declares outputs.
+@testable import PromptyAnthropic
+
+final class AnthropicProcessVectorTests: XCTestCase {
+
+  func testAnthropicProcessVectors() async throws {
+    var run = VectorRun(stage: "process")
+
+    for vector in try Spec.vectors("process") {
+      let name = vector["name"] as? String ?? "<unnamed>"
+      let input = vector["input"] as? [String: Any] ?? [:]
+      let expected = vector["expected"] as? [String: Any] ?? [:]
+
+      guard (input["provider"] as? String ?? "openai") == "anthropic" else { continue }
+      run.started()
+
+      do {
+        let agent = try Self.agent(hasOutputs: input["has_outputs"] as? Bool ?? false)
+        let result = try await AnthropicProcessor().process(
+          agent: agent, response: input["response"] as Any)
+
+        let expectedResult = expected["result"]
+        if Self.isEmptyish(result) && Self.isEmptyish(expectedResult) { continue }
+
+        try expectEqual(result, expectedResult, "result")
+      } catch {
+        run.fail(name, "\(error)")
+      }
+    }
+
+    run.assertClean()
+  }
+
+  private static func agent(hasOutputs: Bool) throws -> Agent {
+    var data: [String: Any] = [
+      "kind": "prompt",
+      "name": "anthropic-process-vectors",
+      "model": ["id": "claude-3", "provider": "anthropic"],
+      "instructions": "test",
+    ]
+    if hasOutputs {
+      data["outputs"] = [["name": "result", "kind": "string"]]
+    }
+    return try Agent.load(data)
+  }
+
+  private static func isEmptyish(_ value: Any?) -> Bool {
+    if value == nil || value is NSNull { return true }
+    if let string = value as? String { return string.isEmpty }
+    return false
+  }
+}

--- a/runtime/swift/prompty/Tests/PromptyTests/AnthropicWireVectorTests.swift
+++ b/runtime/swift/prompty/Tests/PromptyTests/AnthropicWireVectorTests.swift
@@ -1,0 +1,106 @@
+import Foundation
+
+import PromptyModel
+
+import XCTest
+
+@testable import Prompty
+
+/// Conformance against the Anthropic `wire` cases in `vectors.json`.
+///
+/// Builds a real agent from each vector's input and drives ``AnthropicWire`` so
+/// the assertion covers `ModelOptions.toWire("anthropic")`, tool projection and
+/// system extraction rather than a test-local approximation.
+@testable import PromptyAnthropic
+
+final class AnthropicWireVectorTests: XCTestCase {
+
+  func testAnthropicWireVectors() throws {
+    var run = VectorRun(stage: "wire")
+
+    for vector in try Spec.vectors("wire") {
+      let name = vector["name"] as? String ?? "<unnamed>"
+      let input = vector["input"] as? [String: Any] ?? [:]
+      let expected = vector["expected"] as? [String: Any] ?? [:]
+
+      guard (input["provider"] as? String ?? "openai") == "anthropic" else { continue }
+      run.started()
+
+      do {
+        let agent = try Self.agent(from: input)
+        let messages = try Self.messages(from: input)
+        let apiType = input["apiType"] as? String ?? "chat"
+
+        guard apiType == "chat" || apiType == "agent" else {
+          throw InvokerError.execution("Unsupported apiType: \(apiType)")
+        }
+
+        let body = try AnthropicWire.chatArgs(agent, messages: messages)
+
+        guard let expectedBody = expected["request_body"] else { continue }
+        try expectEqual(body, expectedBody, "request_body")
+      } catch {
+        run.fail(name, "\(error)")
+      }
+    }
+
+    run.assertClean()
+  }
+
+  // MARK: - Vector input decoding
+
+  private static func agent(from input: [String: Any]) throws -> Agent {
+    var model: [String: Any] = [
+      "provider": input["provider"] as? String ?? "anthropic"
+    ]
+    if let id = input["model_id"] as? String { model["id"] = id }
+    if let apiType = input["apiType"] as? String { model["apiType"] = apiType }
+    if let options = input["options"] as? [String: Any], !options.isEmpty {
+      model["options"] = options
+    }
+
+    var data: [String: Any] = [
+      "kind": "prompt",
+      "name": "anthropic-wire-vectors",
+      "model": model,
+    ]
+    if let tools = input["tools"] as? [Any], !tools.isEmpty { data["tools"] = tools }
+    if let outputs = input["outputs"] as? [Any], !outputs.isEmpty { data["outputs"] = outputs }
+
+    return try Agent.load(data)
+  }
+
+  private static func messages(from input: [String: Any]) throws -> [Message] {
+    let raw = input["messages"] as? [[String: Any]] ?? []
+    return try raw.map { entry in
+      var message = Message()
+      message.role = try Role.parse(entry["role"] as? String ?? "user")
+      message.parts = try (entry["content"] as? [[String: Any]] ?? []).map(part)
+
+      for (key, value) in entry where key != "role" && key != "content" {
+        message.metadata[key] = value
+      }
+      return message
+    }
+  }
+
+  private static func part(_ raw: [String: Any]) throws -> ContentPart {
+    let kind = raw["kind"] as? String ?? "text"
+    let value = raw["value"] as? String ?? ""
+    let mediaType = raw["mediaType"] as? String
+
+    switch kind {
+    case "text":
+      return .textPart(TextPart(value: value))
+    case "image":
+      return .imagePart(
+        ImagePart(source: value, detail: raw["detail"] as? String, mediaType: mediaType))
+    case "audio":
+      return .audioPart(AudioPart(source: value, mediaType: mediaType))
+    case "file":
+      return .filePart(FilePart(source: value, mediaType: mediaType))
+    default:
+      throw InvokerError.parse("Unknown content kind: \(kind)")
+    }
+  }
+}

--- a/runtime/swift/prompty/Tests/PromptyTests/DatasetDriftTests.swift
+++ b/runtime/swift/prompty/Tests/PromptyTests/DatasetDriftTests.swift
@@ -1,0 +1,39 @@
+import Foundation
+
+import XCTest
+
+@testable import Prompty
+
+/// Guards the vendored capability dataset against drift.
+///
+/// `Sources/Prompty/Resources/model_capabilities.json` is a copy of the
+/// canonical `spec/data/model_capabilities.json` so the package can embed it via
+/// `Bundle.module`. This test fails if the two diverge, forcing the copy to be
+/// refreshed whenever the shared dataset changes.
+final class DatasetDriftTests: XCTestCase {
+
+  func testVendoredDatasetMatchesSpec() throws {
+    let specURL =
+      Spec.repoRoot
+      .appendingPathComponent("spec")
+      .appendingPathComponent("data")
+      .appendingPathComponent("model_capabilities.json")
+
+    let vendoredURL =
+      Spec.repoRoot
+      .appendingPathComponent("runtime")
+      .appendingPathComponent("swift")
+      .appendingPathComponent("prompty")
+      .appendingPathComponent("Sources")
+      .appendingPathComponent("Prompty")
+      .appendingPathComponent("Resources")
+      .appendingPathComponent("model_capabilities.json")
+
+    let specJSON = try JSONSerialization.jsonObject(with: Data(contentsOf: specURL))
+    let vendoredJSON = try JSONSerialization.jsonObject(with: Data(contentsOf: vendoredURL))
+
+    XCTAssertTrue(
+      Spec.equal(vendoredJSON, specJSON),
+      "vendored model_capabilities.json drifted from spec/data/model_capabilities.json")
+  }
+}

--- a/runtime/swift/prompty/Tests/PromptyTests/DiscoveryVectorTests.swift
+++ b/runtime/swift/prompty/Tests/PromptyTests/DiscoveryVectorTests.swift
@@ -1,0 +1,50 @@
+import Foundation
+
+import PromptyModel
+
+import XCTest
+
+@testable import Prompty
+@testable import PromptyAnthropic
+@testable import PromptyFoundry
+@testable import PromptyOpenAI
+
+/// Conformance for the `discovery` stage (`DiscoveryConformance.mapModel`).
+///
+/// Each vector maps a raw provider payload into `ModelInfo` through the same
+/// per-provider mapping the runtime uses, then compares the saved result. The
+/// vector's `provider` and `shape` select the mapping: Foundry distinguishes
+/// catalog entries from deployments.
+final class DiscoveryVectorTests: XCTestCase {
+
+  func testDiscoveryVectors() throws {
+    var run = VectorRun(stage: "discovery")
+
+    for vector in try Spec.vectors("discovery") {
+      let name = vector["name"] as? String ?? "<unnamed>"
+      let provider = vector["provider"] as? String ?? ""
+      let shape = vector["shape"] as? String ?? ""
+      let input = vector["input"] ?? [String: Any]()
+      let expected = vector["expected"] as? [String: Any] ?? [:]
+
+      run.check(name) {
+        let info: ModelInfo
+        switch (provider, shape) {
+        case ("openai", _):
+          info = OpenAIModels.modelInfo(fromWire: input)
+        case ("anthropic", _):
+          info = AnthropicModels.modelInfo(fromWire: input)
+        case ("foundry", "catalog"):
+          info = FoundryModels.modelInfo(fromCatalog: input)
+        case ("foundry", "deployment"):
+          info = FoundryModels.modelInfo(fromDeployment: input)
+        default:
+          throw VectorFailure("unhandled provider/shape: \(provider)/\(shape)")
+        }
+        try expectEqual(info.save(), expected, "model_info")
+      }
+    }
+
+    run.assertClean()
+  }
+}

--- a/runtime/swift/prompty/Tests/PromptyTests/EnrichmentVectorTests.swift
+++ b/runtime/swift/prompty/Tests/PromptyTests/EnrichmentVectorTests.swift
@@ -1,0 +1,35 @@
+import Foundation
+
+import PromptyModel
+
+import XCTest
+
+@testable import Prompty
+
+/// Conformance for the `enrichment` stage (`DiscoveryConformance.enrich`).
+///
+/// Each vector loads a sparse `ModelInfo`, applies the shared dataset
+/// enrichment for its provider, and compares the saved result. Provider-supplied
+/// fields (including a present-but-empty modality list) must always win; the
+/// dataset only fills fields left `nil`.
+final class EnrichmentVectorTests: XCTestCase {
+
+  func testEnrichmentVectors() throws {
+    var run = VectorRun(stage: "enrichment")
+
+    for vector in try Spec.vectors("enrichment") {
+      let name = vector["name"] as? String ?? "<unnamed>"
+      let provider = vector["provider"] as? String ?? ""
+      let input = vector["input"] as? [String: Any] ?? [:]
+      let expected = vector["expected"] as? [String: Any] ?? [:]
+
+      run.check(name) {
+        var info = try ModelInfo.load(input)
+        Discovery.enrich(provider: provider, info: &info)
+        try expectEqual(info.save(), expected, "model_info")
+      }
+    }
+
+    run.assertClean()
+  }
+}


### PR DESCRIPTION
## Summary

Brings the Swift runtime to full parity with the shared TypeSpec-generated conformance vectors, closing the gap that let other runtimes (e.g. Go) silently drift. All work is driven by the real generated vector file (`schema/tsp-output/.typra-generated/vectors.json`), not scratch copies.

## What's included

- **Model discovery + enrichment parity** — Swift model lister/enrichment aligned with the shared contract.
- **Anthropic provider** — wire format + response processor for vector parity.
- **Agent loop** — `Pipeline.turn` with the Python per-iteration ordering (cancel check -> steering drain -> context trim -> input guardrail -> execute -> tool loop with per-call guardrails/cancellation -> output guardrail).
- **Agent-stage vectors: 28/28** — 11 basic + 17 extension (context, guardrails, steering, parallel tools, events, cancellation).
- **Coverage completeness guard** — `testEveryAgentVectorIsCovered` diffs the suite's covered set against the generated `agent` stage and fails loudly on any unwired new vector or stale reference. Runtime-side backstop that complements Typra's forthcoming structural parity enforcement.

## Parity contract

Follows Python's lenient contract (not Rust's strict): result equality + `denied_tools`/`tool_execution_order` for result vectors; thrown error + `error_reason` substring for error vectors; event subset + terminal for event vectors. Turn/engine stage remains Rust-only, matching Python/TS.

## Verification

- `swift test` -> full suite green (191 tests, 0 failures; 10 live skips).
- `swift test --filter AgentVectorTests` -> 10 tests, 0 failures.
- Completeness guard proven to bite: removing one vector name fails the test.
- `swift format --strict` clean on committed content.

Co-authored-by: Copilot App <223556219+Copilot@users.noreply.github.com>
