### PR TITLE
Conformance waiver removal: Go providers (#490) + normalize-script cleanup (#485)

### DIFF
--- a/runtime/go/prompty/providers/anthropic/anthropic.go
+++ b/runtime/go/prompty/providers/anthropic/anthropic.go
@@ -1,0 +1,150 @@
+// Package anthropic provides an HTTP-based Executor and Processor for the
+// Anthropic Messages API. Register them under the "anthropic" provider key with
+// Register.
+package anthropic
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+	"strings"
+
+	prompty "prompty/model"
+	"prompty/providers"
+)
+
+// DefaultEndpoint is the Anthropic API base URL used when the connection does
+// not specify one.
+const DefaultEndpoint = "https://api.anthropic.com"
+
+// APIVersion is the anthropic-version header value sent with every request.
+const APIVersion = "2023-06-01"
+
+// Executor calls the Anthropic Messages API over raw HTTP.
+type Executor struct{}
+
+// Processor normalizes raw Anthropic responses into clean results.
+type Processor struct{}
+
+// Register wires the Anthropic executor and processor into the provider
+// registry under the "anthropic" key.
+func Register() {
+	providers.RegisterExecutor("anthropic", Executor{})
+	providers.RegisterProcessor("anthropic", Processor{})
+}
+
+// Execute builds the Anthropic request body via the shared wire pipeline,
+// resolves the connection, POSTs to /v1/messages, and returns the decoded JSON
+// response.
+func (Executor) Execute(agent prompty.Agent, messages []prompty.Message) (interface{}, error) {
+	input := providers.BuildInput(agent, messages, "anthropic")
+	body, err := prompty.BuildWireRequest(input)
+	if err != nil {
+		return nil, err
+	}
+
+	endpoint, apiKey, err := connectionInfo(agent)
+	if err != nil {
+		return nil, err
+	}
+
+	url := endpoint + "/v1/messages"
+	headers := map[string]string{
+		"x-api-key":         apiKey,
+		"anthropic-version": APIVersion,
+	}
+	return providers.PostJSON(url, headers, body)
+}
+
+// ExecuteStream is not supported by the raw-HTTP Anthropic executor.
+func (Executor) ExecuteStream(agent prompty.Agent, messages []prompty.Message) (interface{}, error) {
+	return nil, providers.ErrStreamingUnsupported
+}
+
+// FormatToolMessages formats a tool-call turn for the Anthropic Messages API:
+// an assistant message that preserves all content blocks (text + tool_use),
+// followed by a single user message batching the tool_result blocks. Mirrors the
+// C# AnthropicExecutor.FormatToolMessages reference.
+func (Executor) FormatToolMessages(rawResponse interface{}, toolCalls []prompty.ToolCall, toolResults []string, textContent *string) ([]prompty.Message, error) {
+	// Assistant message with all content blocks.
+	rawContent := make([]interface{}, 0, len(toolCalls)+1)
+	var assistantParts []interface{}
+	if textContent != nil && *textContent != "" {
+		rawContent = append(rawContent, map[string]interface{}{"type": "text", "text": *textContent})
+		assistantParts = []interface{}{prompty.TextPart{Kind: "text", Value: *textContent}}
+	}
+	for _, tc := range toolCalls {
+		var parsedInput interface{}
+		if tc.Arguments != "" {
+			_ = json.Unmarshal([]byte(tc.Arguments), &parsedInput)
+		}
+		rawContent = append(rawContent, map[string]interface{}{
+			"type":  "tool_use",
+			"id":    tc.Id,
+			"name":  tc.Name,
+			"input": parsedInput,
+		})
+	}
+
+	messages := make([]prompty.Message, 0, 2)
+	messages = append(messages, prompty.Message{
+		Role:     prompty.Role("assistant"),
+		Parts:    assistantParts,
+		Metadata: map[string]interface{}{"content": rawContent},
+	})
+
+	// Single user message batching tool_result blocks.
+	toolResultBlocks := make([]interface{}, 0, len(toolCalls))
+	resultParts := make([]interface{}, 0, len(toolCalls))
+	for i, tc := range toolCalls {
+		result := ""
+		if i < len(toolResults) {
+			result = toolResults[i]
+		}
+		toolResultBlocks = append(toolResultBlocks, map[string]interface{}{
+			"type":        "tool_result",
+			"tool_use_id": tc.Id,
+			"content":     result,
+		})
+		resultParts = append(resultParts, prompty.TextPart{Kind: "text", Value: result})
+	}
+	messages = append(messages, prompty.Message{
+		Role:     prompty.Role("user"),
+		Parts:    resultParts,
+		Metadata: map[string]interface{}{"tool_results": toolResultBlocks},
+	})
+
+	return messages, nil
+}
+
+// Process normalizes a raw Anthropic response via the shared processing
+// pipeline.
+func (Processor) Process(agent prompty.Agent, response interface{}) (interface{}, error) {
+	return prompty.ProcessResponse("anthropic", providers.APIType(agent), response, providers.HasOutputs(agent))
+}
+
+// ProcessStream is not supported by the raw-HTTP Anthropic processor.
+func (Processor) ProcessStream(stream interface{}) (interface{}, error) {
+	return nil, providers.ErrStreamingUnsupported
+}
+
+// connectionInfo resolves the endpoint and API key, falling back to the
+// ANTHROPIC_API_KEY environment variable when the connection omits a key.
+func connectionInfo(agent prompty.Agent) (endpoint, apiKey string, err error) {
+	conn := providers.ResolveConnection(agent)
+	if conn.Kind == "reference" {
+		return "", "", fmt.Errorf("anthropic: reference connections are not supported by the raw HTTP executor; use a key connection with apiKey")
+	}
+	endpoint = strings.TrimRight(conn.Endpoint, "/")
+	if endpoint == "" {
+		endpoint = DefaultEndpoint
+	}
+	apiKey = conn.APIKey
+	if apiKey == "" {
+		apiKey = os.Getenv("ANTHROPIC_API_KEY")
+	}
+	if apiKey == "" {
+		return "", "", fmt.Errorf("anthropic: API key is required (set model.connection.apiKey or ANTHROPIC_API_KEY)")
+	}
+	return endpoint, apiKey, nil
+}

--- a/runtime/go/prompty/providers/anthropic/anthropic_test.go
+++ b/runtime/go/prompty/providers/anthropic/anthropic_test.go
@@ -1,0 +1,146 @@
+package anthropic
+
+import (
+	"encoding/json"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	prompty "prompty/model"
+	"prompty/providers"
+)
+
+func loadAgent(t *testing.T, data map[string]interface{}) prompty.Agent {
+	t.Helper()
+	agent, err := prompty.LoadAgent(data, prompty.NewLoadContext())
+	if err != nil {
+		t.Fatalf("LoadAgent failed: %v", err)
+	}
+	return agent
+}
+
+func keyAgent(t *testing.T, endpoint string) prompty.Agent {
+	return loadAgent(t, map[string]interface{}{
+		"name": "t",
+		"model": map[string]interface{}{
+			"id": "claude-sonnet-4",
+			"connection": map[string]interface{}{
+				"kind":     "key",
+				"endpoint": endpoint,
+				"apiKey":   "ant-test",
+			},
+		},
+	})
+}
+
+func TestExecuteMessages(t *testing.T) {
+	var gotPath, gotKey, gotVersion string
+	var gotBody map[string]interface{}
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotPath = r.URL.Path
+		gotKey = r.Header.Get("x-api-key")
+		gotVersion = r.Header.Get("anthropic-version")
+		data, _ := io.ReadAll(r.Body)
+		_ = json.Unmarshal(data, &gotBody)
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"content":[{"type":"text","text":"hi"}]}`))
+	}))
+	defer srv.Close()
+
+	messages := []prompty.Message{
+		{Role: prompty.Role("system"), Parts: []interface{}{prompty.TextPart{Kind: "text", Value: "be nice"}}},
+		{Role: prompty.Role("user"), Parts: []interface{}{prompty.TextPart{Kind: "text", Value: "hello"}}},
+	}
+	if _, err := (Executor{}).Execute(keyAgent(t, srv.URL), messages); err != nil {
+		t.Fatalf("Execute: %v", err)
+	}
+	if gotPath != "/v1/messages" {
+		t.Fatalf("path = %q", gotPath)
+	}
+	if gotKey != "ant-test" {
+		t.Fatalf("x-api-key = %q", gotKey)
+	}
+	if gotVersion != APIVersion {
+		t.Fatalf("anthropic-version = %q", gotVersion)
+	}
+	if gotBody["system"] != "be nice" {
+		t.Fatalf("expected system extracted, body = %v", gotBody)
+	}
+}
+
+func TestReferenceConnectionUnsupported(t *testing.T) {
+	agent := loadAgent(t, map[string]interface{}{
+		"name": "t",
+		"model": map[string]interface{}{
+			"id":         "claude",
+			"connection": map[string]interface{}{"kind": "reference", "name": "my-conn"},
+		},
+	})
+	if _, err := (Executor{}).Execute(agent, nil); err == nil {
+		t.Fatal("expected error for reference connection")
+	}
+}
+
+func TestProcess(t *testing.T) {
+	agent := keyAgent(t, "https://example.com")
+	resp := map[string]interface{}{"content": []interface{}{map[string]interface{}{"type": "text", "text": "answer"}}}
+	out, err := Processor{}.Process(agent, resp)
+	if err != nil {
+		t.Fatalf("Process: %v", err)
+	}
+	if out != "answer" {
+		t.Fatalf("process result = %v", out)
+	}
+}
+
+func TestFormatToolMessages(t *testing.T) {
+	text := "let me check"
+	calls := []prompty.ToolCall{{Id: "tu1", Name: "get_weather", Arguments: `{"city":"NYC"}`}}
+	msgs, err := Executor{}.FormatToolMessages(nil, calls, []string{"72F"}, &text)
+	if err != nil {
+		t.Fatalf("FormatToolMessages: %v", err)
+	}
+	if len(msgs) != 2 {
+		t.Fatalf("expected 2 messages, got %d", len(msgs))
+	}
+	content, ok := msgs[0].Metadata["content"].([]interface{})
+	if !ok || len(content) != 2 {
+		t.Fatalf("assistant content blocks = %v", msgs[0].Metadata["content"])
+	}
+	toolUse := content[1].(map[string]interface{})
+	if toolUse["type"] != "tool_use" || toolUse["id"] != "tu1" {
+		t.Fatalf("tool_use block = %v", toolUse)
+	}
+	input, ok := toolUse["input"].(map[string]interface{})
+	if !ok || input["city"] != "NYC" {
+		t.Fatalf("tool_use input = %v", toolUse["input"])
+	}
+	results, ok := msgs[1].Metadata["tool_results"].([]interface{})
+	if !ok || len(results) != 1 {
+		t.Fatalf("tool_results = %v", msgs[1].Metadata["tool_results"])
+	}
+	block := results[0].(map[string]interface{})
+	if block["type"] != "tool_result" || block["tool_use_id"] != "tu1" || block["content"] != "72F" {
+		t.Fatalf("tool_result block = %v", block)
+	}
+}
+
+func TestStreamingUnsupported(t *testing.T) {
+	if _, err := (Executor{}).ExecuteStream(keyAgent(t, "https://x"), nil); err != providers.ErrStreamingUnsupported {
+		t.Fatalf("ExecuteStream err = %v", err)
+	}
+	if _, err := (Processor{}).ProcessStream(nil); err != providers.ErrStreamingUnsupported {
+		t.Fatalf("ProcessStream err = %v", err)
+	}
+}
+
+func TestRegister(t *testing.T) {
+	Register()
+	if _, ok := providers.GetExecutor("anthropic"); !ok {
+		t.Fatal("anthropic executor not registered")
+	}
+	if _, ok := providers.GetProcessor("anthropic"); !ok {
+		t.Fatal("anthropic processor not registered")
+	}
+}

--- a/runtime/go/prompty/providers/foundry/foundry.go
+++ b/runtime/go/prompty/providers/foundry/foundry.go
@@ -1,0 +1,128 @@
+// Package foundry provides an HTTP-based Executor and Processor for Azure OpenAI
+// / Microsoft Foundry endpoints. It reuses the OpenAI wire family (chat,
+// embedding, image) but targets Azure's deployment-scoped URLs and auth. Register
+// them under the "foundry" provider key with Register.
+package foundry
+
+import (
+	"fmt"
+	"os"
+	"strings"
+
+	prompty "prompty/model"
+	"prompty/providers"
+)
+
+// DefaultAPIVersion is the Azure OpenAI api-version query parameter used for all
+// requests.
+const DefaultAPIVersion = "2024-12-01-preview"
+
+// AccessTokenEnv is the environment variable consulted for an Entra ID bearer
+// token when the connection carries no API key (Foundry connections).
+const AccessTokenEnv = "AZURE_OPENAI_ACCESS_TOKEN"
+
+// Executor calls Azure OpenAI / Foundry deployments over raw HTTP.
+type Executor struct{}
+
+// Processor normalizes raw Azure OpenAI responses into clean results.
+type Processor struct{}
+
+// Register wires the Foundry executor and processor into the provider registry
+// under the "foundry" key.
+func Register() {
+	providers.RegisterExecutor("foundry", Executor{})
+	providers.RegisterProcessor("foundry", Processor{})
+}
+
+// Execute builds the request body via the shared OpenAI wire pipeline, resolves
+// the Azure connection, POSTs to the deployment-scoped endpoint, and returns the
+// decoded JSON response.
+func (Executor) Execute(agent prompty.Agent, messages []prompty.Message) (interface{}, error) {
+	input := providers.BuildInput(agent, messages, "openai")
+	body, err := prompty.BuildWireRequest(input)
+	if err != nil {
+		return nil, err
+	}
+
+	url, headers, err := requestTarget(agent)
+	if err != nil {
+		return nil, err
+	}
+	return providers.PostJSON(url, headers, body)
+}
+
+// ExecuteStream is not supported by the raw-HTTP Foundry executor.
+func (Executor) ExecuteStream(agent prompty.Agent, messages []prompty.Message) (interface{}, error) {
+	return nil, providers.ErrStreamingUnsupported
+}
+
+// FormatToolMessages formats a tool-call turn for the chat completions loop
+// (identical to the OpenAI wire format).
+func (Executor) FormatToolMessages(rawResponse interface{}, toolCalls []prompty.ToolCall, toolResults []string, textContent *string) ([]prompty.Message, error) {
+	return providers.FormatChatToolMessages(toolCalls, toolResults, textContent), nil
+}
+
+// Process normalizes a raw Azure OpenAI response via the shared OpenAI
+// processing pipeline.
+func (Processor) Process(agent prompty.Agent, response interface{}) (interface{}, error) {
+	return prompty.ProcessResponse("openai", providers.APIType(agent), response, providers.HasOutputs(agent))
+}
+
+// ProcessStream is not supported by the raw-HTTP Foundry processor.
+func (Processor) ProcessStream(stream interface{}) (interface{}, error) {
+	return nil, providers.ErrStreamingUnsupported
+}
+
+// requestTarget resolves the request URL and auth headers for the agent's Azure
+// connection. API-key connections use the deployment-scoped URL with an api-key
+// header; keyless (Foundry/Entra) connections use an AZURE_OPENAI_ACCESS_TOKEN
+// bearer token against the OpenAI/v1 base URL.
+func requestTarget(agent prompty.Agent) (url string, headers map[string]string, err error) {
+	conn := providers.ResolveConnection(agent)
+	endpoint := strings.TrimRight(conn.Endpoint, "/")
+	if endpoint == "" {
+		endpoint = strings.TrimRight(os.Getenv("AZURE_OPENAI_ENDPOINT"), "/")
+	}
+	if endpoint == "" {
+		return "", nil, fmt.Errorf("foundry: endpoint is required (set model.connection.endpoint or AZURE_OPENAI_ENDPOINT)")
+	}
+
+	deployment := ""
+	if agent.Model != nil {
+		deployment = agent.Model.Id
+	}
+	if deployment == "" {
+		return "", nil, fmt.Errorf("foundry: model id (deployment name) is required")
+	}
+
+	op := operationPath(providers.APIType(agent))
+
+	apiKey := conn.APIKey
+	if apiKey == "" {
+		apiKey = os.Getenv("AZURE_OPENAI_API_KEY")
+	}
+	if apiKey != "" {
+		url = fmt.Sprintf("%s/openai/deployments/%s%s?api-version=%s", endpoint, deployment, op, DefaultAPIVersion)
+		return url, map[string]string{"api-key": apiKey}, nil
+	}
+
+	if token := os.Getenv(AccessTokenEnv); token != "" {
+		url = endpoint + "/openai/v1" + op
+		return url, map[string]string{"Authorization": "Bearer " + token}, nil
+	}
+
+	return "", nil, fmt.Errorf("foundry: no credentials (set model.connection.apiKey, AZURE_OPENAI_API_KEY, or %s)", AccessTokenEnv)
+}
+
+func operationPath(apiType string) string {
+	switch apiType {
+	case "embedding":
+		return "/embeddings"
+	case "image":
+		return "/images/generations"
+	case "responses":
+		return "/responses"
+	default: // chat, agent
+		return "/chat/completions"
+	}
+}

--- a/runtime/go/prompty/providers/foundry/foundry_test.go
+++ b/runtime/go/prompty/providers/foundry/foundry_test.go
@@ -1,0 +1,146 @@
+package foundry
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	prompty "prompty/model"
+	"prompty/providers"
+)
+
+func loadAgent(t *testing.T, data map[string]interface{}) prompty.Agent {
+	t.Helper()
+	agent, err := prompty.LoadAgent(data, prompty.NewLoadContext())
+	if err != nil {
+		t.Fatalf("LoadAgent failed: %v", err)
+	}
+	return agent
+}
+
+func userMsg(text string) []prompty.Message {
+	return []prompty.Message{{Role: prompty.Role("user"), Parts: []interface{}{prompty.TextPart{Kind: "text", Value: text}}}}
+}
+
+func TestExecuteApiKey(t *testing.T) {
+	var gotPath, gotQuery, gotKey string
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotPath = r.URL.Path
+		gotQuery = r.URL.RawQuery
+		gotKey = r.Header.Get("api-key")
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"choices":[]}`))
+	}))
+	defer srv.Close()
+
+	agent := loadAgent(t, map[string]interface{}{
+		"name": "t",
+		"model": map[string]interface{}{
+			"id": "my-deployment",
+			"connection": map[string]interface{}{
+				"kind":     "key",
+				"endpoint": srv.URL,
+				"apiKey":   "azure-key",
+			},
+		},
+	})
+	if _, err := (Executor{}).Execute(agent, userMsg("hi")); err != nil {
+		t.Fatalf("Execute: %v", err)
+	}
+	if gotPath != "/openai/deployments/my-deployment/chat/completions" {
+		t.Fatalf("path = %q", gotPath)
+	}
+	if gotQuery != "api-version="+DefaultAPIVersion {
+		t.Fatalf("query = %q", gotQuery)
+	}
+	if gotKey != "azure-key" {
+		t.Fatalf("api-key = %q", gotKey)
+	}
+}
+
+func TestExecuteAccessToken(t *testing.T) {
+	t.Setenv("AZURE_OPENAI_API_KEY", "")
+	t.Setenv("AZURE_OPENAI_ACCESS_TOKEN", "tok-123")
+	var gotPath, gotAuth string
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotPath = r.URL.Path
+		gotAuth = r.Header.Get("Authorization")
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"choices":[]}`))
+	}))
+	defer srv.Close()
+
+	agent := loadAgent(t, map[string]interface{}{
+		"name": "t",
+		"model": map[string]interface{}{
+			"id":         "dep",
+			"connection": map[string]interface{}{"kind": "foundry", "endpoint": srv.URL},
+		},
+	})
+	if _, err := (Executor{}).Execute(agent, userMsg("hi")); err != nil {
+		t.Fatalf("Execute: %v", err)
+	}
+	if gotPath != "/openai/v1/chat/completions" {
+		t.Fatalf("path = %q", gotPath)
+	}
+	if gotAuth != "Bearer tok-123" {
+		t.Fatalf("auth = %q", gotAuth)
+	}
+}
+
+func TestExecuteMissingEndpoint(t *testing.T) {
+	t.Setenv("AZURE_OPENAI_ENDPOINT", "")
+	agent := loadAgent(t, map[string]interface{}{"name": "t", "model": map[string]interface{}{"id": "dep"}})
+	if _, err := (Executor{}).Execute(agent, userMsg("hi")); err == nil {
+		t.Fatal("expected error when endpoint missing")
+	}
+}
+
+func TestExecuteMissingCreds(t *testing.T) {
+	t.Setenv("AZURE_OPENAI_API_KEY", "")
+	t.Setenv("AZURE_OPENAI_ACCESS_TOKEN", "")
+	agent := loadAgent(t, map[string]interface{}{
+		"name": "t",
+		"model": map[string]interface{}{
+			"id":         "dep",
+			"connection": map[string]interface{}{"kind": "foundry", "endpoint": "https://example.com"},
+		},
+	})
+	if _, err := (Executor{}).Execute(agent, userMsg("hi")); err == nil {
+		t.Fatal("expected error when no credentials present")
+	}
+}
+
+func TestProcess(t *testing.T) {
+	agent := loadAgent(t, map[string]interface{}{"name": "t", "model": map[string]interface{}{"id": "dep"}})
+	resp := map[string]interface{}{
+		"choices": []interface{}{map[string]interface{}{"message": map[string]interface{}{"content": "ok"}}},
+	}
+	out, err := Processor{}.Process(agent, resp)
+	if err != nil {
+		t.Fatalf("Process: %v", err)
+	}
+	if out != "ok" {
+		t.Fatalf("process result = %v", out)
+	}
+}
+
+func TestStreamingUnsupported(t *testing.T) {
+	agent := loadAgent(t, map[string]interface{}{"name": "t", "model": map[string]interface{}{"id": "dep"}})
+	if _, err := (Executor{}).ExecuteStream(agent, nil); err != providers.ErrStreamingUnsupported {
+		t.Fatalf("ExecuteStream err = %v", err)
+	}
+	if _, err := (Processor{}).ProcessStream(nil); err != providers.ErrStreamingUnsupported {
+		t.Fatalf("ProcessStream err = %v", err)
+	}
+}
+
+func TestRegister(t *testing.T) {
+	Register()
+	if _, ok := providers.GetExecutor("foundry"); !ok {
+		t.Fatal("foundry executor not registered")
+	}
+	if _, ok := providers.GetProcessor("foundry"); !ok {
+		t.Fatal("foundry processor not registered")
+	}
+}

--- a/runtime/go/prompty/providers/helpers.go
+++ b/runtime/go/prompty/providers/helpers.go
@@ -1,0 +1,263 @@
+// Shared helpers for the built-in HTTP providers: canonical wire-input
+// construction, connection resolution, JSON transport, and tool-message
+// formatting. These are consumed by the openai, anthropic, and foundry
+// sub-packages so the provider-specific files stay thin.
+
+package providers
+
+import (
+	"bytes"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"net/http"
+
+	prompty "prompty/model"
+)
+
+// ErrStreamingUnsupported is returned by ExecuteStream / ProcessStream for the
+// raw-HTTP providers, which do not implement streaming.
+var ErrStreamingUnsupported = errors.New("streaming is not supported by this provider")
+
+// DefaultHTTPClient is the shared client used by all providers. Callers may
+// replace it (e.g. in tests) before invoking an executor.
+var DefaultHTTPClient = &http.Client{}
+
+// BuildInput assembles the canonical wire-input map consumed by
+// model.BuildWireRequest from an Agent and its rendered messages. wireProvider
+// selects the wire family ("openai" or "anthropic"); Foundry/Azure use "openai".
+func BuildInput(agent prompty.Agent, messages []prompty.Message, wireProvider string) map[string]interface{} {
+	input := map[string]interface{}{
+		"provider": wireProvider,
+		"messages": messagesToWire(messages),
+	}
+	if agent.Model != nil {
+		saved := agent.Model.Save(prompty.NewSaveContext())
+		if v, ok := saved["id"]; ok {
+			input["model_id"] = v
+		}
+		if v, ok := saved["apiType"]; ok {
+			input["apiType"] = v
+		}
+		if v, ok := saved["options"]; ok {
+			input["options"] = v
+		}
+	}
+	if len(agent.Tools) > 0 {
+		input["tools"] = saveSlice(agent.Tools)
+	}
+	if len(agent.Outputs) > 0 {
+		input["outputs"] = saveSlice(agent.Outputs)
+	}
+	return input
+}
+
+// APIType returns the agent's declared API type, defaulting to "chat".
+func APIType(agent prompty.Agent) string {
+	if agent.Model != nil && agent.Model.ApiType != nil {
+		return string(*agent.Model.ApiType)
+	}
+	return "chat"
+}
+
+// HasOutputs reports whether the agent declared structured outputs.
+func HasOutputs(agent prompty.Agent) bool {
+	return len(agent.Outputs) > 0
+}
+
+// messagesToWire converts rendered messages into the canonical wire shape:
+// [{role, content: [{kind, value, mediaType?}], metadata?}]. Media parts map
+// their Source field to "value" (the key the wire builders consume).
+func messagesToWire(messages []prompty.Message) []interface{} {
+	out := make([]interface{}, 0, len(messages))
+	for _, msg := range messages {
+		content := make([]interface{}, 0, len(msg.Parts))
+		for _, p := range msg.Parts {
+			content = append(content, partToWire(p))
+		}
+		m := map[string]interface{}{"role": string(msg.Role), "content": content}
+		if len(msg.Metadata) > 0 {
+			m["metadata"] = msg.Metadata
+		}
+		out = append(out, m)
+	}
+	return out
+}
+
+func partToWire(p interface{}) map[string]interface{} {
+	switch tp := p.(type) {
+	case prompty.TextPart:
+		return map[string]interface{}{"kind": tp.Kind, "value": tp.Value}
+	case *prompty.TextPart:
+		if tp == nil {
+			return map[string]interface{}{}
+		}
+		return map[string]interface{}{"kind": tp.Kind, "value": tp.Value}
+	case prompty.ImagePart:
+		return mediaToWire(tp.Kind, tp.Source, tp.MediaType)
+	case *prompty.ImagePart:
+		if tp == nil {
+			return map[string]interface{}{}
+		}
+		return mediaToWire(tp.Kind, tp.Source, tp.MediaType)
+	case prompty.AudioPart:
+		return mediaToWire(tp.Kind, tp.Source, tp.MediaType)
+	case *prompty.AudioPart:
+		if tp == nil {
+			return map[string]interface{}{}
+		}
+		return mediaToWire(tp.Kind, tp.Source, tp.MediaType)
+	case prompty.FilePart:
+		return mediaToWire(tp.Kind, tp.Source, tp.MediaType)
+	case *prompty.FilePart:
+		if tp == nil {
+			return map[string]interface{}{}
+		}
+		return mediaToWire(tp.Kind, tp.Source, tp.MediaType)
+	case map[string]interface{}:
+		return tp
+	default:
+		return map[string]interface{}{}
+	}
+}
+
+func mediaToWire(kind, source string, mediaType *string) map[string]interface{} {
+	m := map[string]interface{}{"kind": kind, "value": source}
+	if mediaType != nil {
+		m["mediaType"] = *mediaType
+	}
+	return m
+}
+
+// saveSlice serializes a slice of typed model values (tools, outputs) into their
+// canonical map form for the wire builders.
+func saveSlice(items []interface{}) []interface{} {
+	out := make([]interface{}, 0, len(items))
+	for _, it := range items {
+		if s, ok := it.(interface {
+			Save(*prompty.SaveContext) map[string]interface{}
+		}); ok {
+			out = append(out, s.Save(prompty.NewSaveContext()))
+		} else if m, ok := it.(map[string]interface{}); ok {
+			out = append(out, m)
+		}
+	}
+	return out
+}
+
+// ConnectionInfo is the resolved connection detail a provider needs to build a
+// request URL and authenticate.
+type ConnectionInfo struct {
+	Kind     string
+	Endpoint string
+	APIKey   string
+	Name     string
+}
+
+// ResolveConnection extracts connection details from an agent's model. It
+// handles typed connection structs (via their Save method) and raw maps. The
+// returned info is best-effort; providers validate the fields they require.
+func ResolveConnection(agent prompty.Agent) ConnectionInfo {
+	info := ConnectionInfo{}
+	if agent.Model == nil || agent.Model.Connection == nil {
+		return info
+	}
+	m := connectionToMap(agent.Model.Connection)
+	if m == nil {
+		return info
+	}
+	info.Kind, _ = m["kind"].(string)
+	info.Endpoint, _ = m["endpoint"].(string)
+	info.APIKey, _ = m["apiKey"].(string)
+	info.Name, _ = m["name"].(string)
+	return info
+}
+
+func connectionToMap(conn interface{}) map[string]interface{} {
+	if conn == nil {
+		return nil
+	}
+	if m, ok := conn.(map[string]interface{}); ok {
+		return m
+	}
+	if s, ok := conn.(interface {
+		Save(*prompty.SaveContext) map[string]interface{}
+	}); ok {
+		return s.Save(prompty.NewSaveContext())
+	}
+	return nil
+}
+
+// PostJSON marshals body, POSTs it to url with the given headers, and decodes
+// the JSON response into a map. Non-2xx responses return an error that includes
+// the response body.
+func PostJSON(url string, headers map[string]string, body map[string]interface{}) (map[string]interface{}, error) {
+	payload, err := json.Marshal(body)
+	if err != nil {
+		return nil, fmt.Errorf("marshal request body: %w", err)
+	}
+	req, err := http.NewRequest(http.MethodPost, url, bytes.NewReader(payload))
+	if err != nil {
+		return nil, fmt.Errorf("build request: %w", err)
+	}
+	req.Header.Set("Content-Type", "application/json")
+	for k, v := range headers {
+		req.Header.Set(k, v)
+	}
+	resp, err := DefaultHTTPClient.Do(req)
+	if err != nil {
+		return nil, fmt.Errorf("http request failed: %w", err)
+	}
+	defer resp.Body.Close()
+
+	data, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return nil, fmt.Errorf("read response body: %w", err)
+	}
+	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
+		return nil, fmt.Errorf("provider returned status %d: %s", resp.StatusCode, string(data))
+	}
+
+	var result map[string]interface{}
+	if err := json.Unmarshal(data, &result); err != nil {
+		return nil, fmt.Errorf("decode response body: %w", err)
+	}
+	return result, nil
+}
+
+// FormatChatToolMessages builds the follow-up conversation turn for the OpenAI /
+// Azure chat-completions tool-calling loop: one assistant message carrying the
+// tool_calls metadata, followed by one tool message per result. Mirrors the C#
+// OpenAIExecutor.FormatToolMessages chat path.
+func FormatChatToolMessages(toolCalls []prompty.ToolCall, toolResults []string, textContent *string) []prompty.Message {
+	messages := make([]prompty.Message, 0, len(toolCalls)+1)
+
+	var assistantParts []interface{}
+	if textContent != nil && *textContent != "" {
+		assistantParts = []interface{}{prompty.TextPart{Kind: "text", Value: *textContent}}
+	}
+	callsCopy := make([]prompty.ToolCall, len(toolCalls))
+	copy(callsCopy, toolCalls)
+	messages = append(messages, prompty.Message{
+		Role:     prompty.Role("assistant"),
+		Parts:    assistantParts,
+		Metadata: map[string]interface{}{"tool_calls": callsCopy},
+	})
+
+	for i, tc := range toolCalls {
+		result := ""
+		if i < len(toolResults) {
+			result = toolResults[i]
+		}
+		messages = append(messages, prompty.Message{
+			Role:  prompty.Role("tool"),
+			Parts: []interface{}{prompty.TextPart{Kind: "text", Value: result}},
+			Metadata: map[string]interface{}{
+				"tool_call_id": tc.Id,
+				"name":         tc.Name,
+			},
+		})
+	}
+	return messages
+}

--- a/runtime/go/prompty/providers/openai/openai.go
+++ b/runtime/go/prompty/providers/openai/openai.go
@@ -1,0 +1,101 @@
+// Package openai provides an HTTP-based Executor and Processor for the OpenAI
+// Chat Completions, Responses, Embeddings, and Images APIs. Register them under
+// the "openai" provider key with Register.
+package openai
+
+import (
+	"fmt"
+	"os"
+	"strings"
+
+	prompty "prompty/model"
+	"prompty/providers"
+)
+
+// DefaultEndpoint is the OpenAI API base URL used when the connection does not
+// specify one.
+const DefaultEndpoint = "https://api.openai.com/v1"
+
+// Executor calls the OpenAI REST APIs over raw HTTP.
+type Executor struct{}
+
+// Processor normalizes raw OpenAI responses into clean results.
+type Processor struct{}
+
+// Register wires the OpenAI executor and processor into the provider registry
+// under the "openai" key.
+func Register() {
+	providers.RegisterExecutor("openai", Executor{})
+	providers.RegisterProcessor("openai", Processor{})
+}
+
+// Execute builds the request body via the shared wire pipeline, resolves the
+// connection, POSTs to the appropriate OpenAI endpoint, and returns the decoded
+// JSON response.
+func (Executor) Execute(agent prompty.Agent, messages []prompty.Message) (interface{}, error) {
+	input := providers.BuildInput(agent, messages, "openai")
+	body, err := prompty.BuildWireRequest(input)
+	if err != nil {
+		return nil, err
+	}
+
+	endpoint, apiKey, err := connectionInfo(agent)
+	if err != nil {
+		return nil, err
+	}
+
+	url := endpoint + operationPath(providers.APIType(agent))
+	headers := map[string]string{"Authorization": "Bearer " + apiKey}
+	return providers.PostJSON(url, headers, body)
+}
+
+// ExecuteStream is not supported by the raw-HTTP OpenAI executor.
+func (Executor) ExecuteStream(agent prompty.Agent, messages []prompty.Message) (interface{}, error) {
+	return nil, providers.ErrStreamingUnsupported
+}
+
+// FormatToolMessages formats a tool-call turn for the chat completions loop.
+func (Executor) FormatToolMessages(rawResponse interface{}, toolCalls []prompty.ToolCall, toolResults []string, textContent *string) ([]prompty.Message, error) {
+	return providers.FormatChatToolMessages(toolCalls, toolResults, textContent), nil
+}
+
+// Process normalizes a raw OpenAI response via the shared processing pipeline.
+func (Processor) Process(agent prompty.Agent, response interface{}) (interface{}, error) {
+	return prompty.ProcessResponse("openai", providers.APIType(agent), response, providers.HasOutputs(agent))
+}
+
+// ProcessStream is not supported by the raw-HTTP OpenAI processor.
+func (Processor) ProcessStream(stream interface{}) (interface{}, error) {
+	return nil, providers.ErrStreamingUnsupported
+}
+
+// connectionInfo resolves the endpoint and API key, falling back to the
+// OPENAI_API_KEY environment variable when the connection omits a key.
+func connectionInfo(agent prompty.Agent) (endpoint, apiKey string, err error) {
+	conn := providers.ResolveConnection(agent)
+	endpoint = strings.TrimRight(conn.Endpoint, "/")
+	if endpoint == "" {
+		endpoint = DefaultEndpoint
+	}
+	apiKey = conn.APIKey
+	if apiKey == "" {
+		apiKey = os.Getenv("OPENAI_API_KEY")
+	}
+	if apiKey == "" {
+		return "", "", fmt.Errorf("openai: API key is required (set model.connection.apiKey or OPENAI_API_KEY)")
+	}
+	return endpoint, apiKey, nil
+}
+
+func operationPath(apiType string) string {
+	switch apiType {
+	case "embedding":
+		return "/embeddings"
+	case "image":
+		return "/images/generations"
+	case "responses":
+		return "/responses"
+	default: // chat, agent
+		return "/chat/completions"
+	}
+}

--- a/runtime/go/prompty/providers/openai/openai_test.go
+++ b/runtime/go/prompty/providers/openai/openai_test.go
@@ -1,0 +1,150 @@
+package openai
+
+import (
+	"encoding/json"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	prompty "prompty/model"
+	"prompty/providers"
+)
+
+func loadAgent(t *testing.T, data map[string]interface{}) prompty.Agent {
+	t.Helper()
+	agent, err := prompty.LoadAgent(data, prompty.NewLoadContext())
+	if err != nil {
+		t.Fatalf("LoadAgent failed: %v", err)
+	}
+	return agent
+}
+
+func keyAgent(t *testing.T, endpoint string) prompty.Agent {
+	return loadAgent(t, map[string]interface{}{
+		"name": "t",
+		"model": map[string]interface{}{
+			"id": "gpt-4",
+			"connection": map[string]interface{}{
+				"kind":     "key",
+				"endpoint": endpoint,
+				"apiKey":   "sk-test",
+			},
+		},
+	})
+}
+
+func userMsg(text string) []prompty.Message {
+	return []prompty.Message{{Role: prompty.Role("user"), Parts: []interface{}{prompty.TextPart{Kind: "text", Value: text}}}}
+}
+
+func TestExecuteChat(t *testing.T) {
+	var gotPath, gotAuth string
+	var gotBody map[string]interface{}
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotPath = r.URL.Path
+		gotAuth = r.Header.Get("Authorization")
+		data, _ := io.ReadAll(r.Body)
+		_ = json.Unmarshal(data, &gotBody)
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"choices":[{"message":{"content":"hello"}}]}`))
+	}))
+	defer srv.Close()
+
+	resp, err := Executor{}.Execute(keyAgent(t, srv.URL), userMsg("hi"))
+	if err != nil {
+		t.Fatalf("Execute: %v", err)
+	}
+	if gotPath != "/chat/completions" {
+		t.Fatalf("path = %q", gotPath)
+	}
+	if gotAuth != "Bearer sk-test" {
+		t.Fatalf("auth = %q", gotAuth)
+	}
+	if gotBody["model"] != "gpt-4" {
+		t.Fatalf("body model = %v", gotBody["model"])
+	}
+	if _, ok := resp.(map[string]interface{}); !ok {
+		t.Fatalf("expected map response, got %T", resp)
+	}
+}
+
+func TestExecuteMissingKey(t *testing.T) {
+	t.Setenv("OPENAI_API_KEY", "")
+	agent := loadAgent(t, map[string]interface{}{"name": "t", "model": map[string]interface{}{"id": "gpt-4"}})
+	if _, err := (Executor{}).Execute(agent, userMsg("hi")); err == nil {
+		t.Fatal("expected error when no API key present")
+	}
+}
+
+func TestExecuteEnvKeyFallback(t *testing.T) {
+	t.Setenv("OPENAI_API_KEY", "sk-env")
+	var gotAuth string
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotAuth = r.Header.Get("Authorization")
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"choices":[]}`))
+	}))
+	defer srv.Close()
+
+	agent := loadAgent(t, map[string]interface{}{
+		"name": "t",
+		"model": map[string]interface{}{
+			"id":         "gpt-4",
+			"connection": map[string]interface{}{"kind": "anonymous", "endpoint": srv.URL},
+		},
+	})
+	if _, err := (Executor{}).Execute(agent, userMsg("hi")); err != nil {
+		t.Fatalf("Execute: %v", err)
+	}
+	if gotAuth != "Bearer sk-env" {
+		t.Fatalf("auth = %q", gotAuth)
+	}
+}
+
+func TestProcessChat(t *testing.T) {
+	agent := keyAgent(t, "https://example.com")
+	resp := map[string]interface{}{
+		"choices": []interface{}{
+			map[string]interface{}{"message": map[string]interface{}{"content": "hi there"}},
+		},
+	}
+	out, err := Processor{}.Process(agent, resp)
+	if err != nil {
+		t.Fatalf("Process: %v", err)
+	}
+	if out != "hi there" {
+		t.Fatalf("process result = %v", out)
+	}
+}
+
+func TestFormatToolMessages(t *testing.T) {
+	calls := []prompty.ToolCall{{Id: "c1", Name: "f", Arguments: "{}"}}
+	msgs, err := Executor{}.FormatToolMessages(nil, calls, []string{"r1"}, nil)
+	if err != nil {
+		t.Fatalf("FormatToolMessages: %v", err)
+	}
+	if len(msgs) != 2 || string(msgs[0].Role) != "assistant" || string(msgs[1].Role) != "tool" {
+		t.Fatalf("unexpected messages: %+v", msgs)
+	}
+}
+
+func TestStreamingUnsupported(t *testing.T) {
+	agent := keyAgent(t, "https://example.com")
+	if _, err := (Executor{}).ExecuteStream(agent, userMsg("hi")); err != providers.ErrStreamingUnsupported {
+		t.Fatalf("ExecuteStream err = %v", err)
+	}
+	if _, err := (Processor{}).ProcessStream(nil); err != providers.ErrStreamingUnsupported {
+		t.Fatalf("ProcessStream err = %v", err)
+	}
+}
+
+func TestRegister(t *testing.T) {
+	Register()
+	if _, ok := providers.GetExecutor("openai"); !ok {
+		t.Fatal("openai executor not registered")
+	}
+	if _, ok := providers.GetProcessor("openai"); !ok {
+		t.Fatal("openai processor not registered")
+	}
+}

--- a/runtime/go/prompty/providers/providers.go
+++ b/runtime/go/prompty/providers/providers.go
@@ -1,0 +1,62 @@
+// Package providers implements HTTP-based Executor/Processor pairs for the
+// built-in LLM providers (openai, anthropic, foundry) and a small registry that
+// resolves them by provider key.
+//
+// Each provider builds a provider-specific request body via the shared
+// model.BuildWireRequest pipeline, performs a raw net/http POST, and normalizes
+// the response via model.ProcessResponse. This mirrors the C# / Rust reference
+// provider packages (Prompty.OpenAI, prompty-openai, ...) while following Go
+// conventions: a single module, explicit Register functions, and no init-time
+// side effects. Import the desired sub-package and call its Register function to
+// wire the executor/processor into the registry:
+//
+//	import "prompty/providers/openai"
+//	openai.Register()
+//	exec, _ := providers.GetExecutor("openai")
+package providers
+
+import (
+	"sync"
+
+	prompty "prompty/model"
+)
+
+var (
+	registryMu sync.RWMutex
+	executors  = map[string]prompty.Executor{}
+	processors = map[string]prompty.Processor{}
+)
+
+// RegisterExecutor registers an Executor under a provider key (e.g. "openai").
+// A later registration for the same key replaces the earlier one.
+func RegisterExecutor(key string, executor prompty.Executor) {
+	registryMu.Lock()
+	defer registryMu.Unlock()
+	executors[key] = executor
+}
+
+// RegisterProcessor registers a Processor under a provider key (e.g. "openai").
+// A later registration for the same key replaces the earlier one.
+func RegisterProcessor(key string, processor prompty.Processor) {
+	registryMu.Lock()
+	defer registryMu.Unlock()
+	processors[key] = processor
+}
+
+// GetExecutor returns the Executor registered under key, or ok=false when no
+// executor is registered for that provider.
+func GetExecutor(key string) (prompty.Executor, bool) {
+	registryMu.RLock()
+	defer registryMu.RUnlock()
+	e, ok := executors[key]
+	return e, ok
+}
+
+// GetProcessor returns the Processor registered under key, or ok=false when no
+// processor is registered for that provider.
+func GetProcessor(key string) (prompty.Processor, bool) {
+	registryMu.RLock()
+	defer registryMu.RUnlock()
+	p, ok := processors[key]
+	return p, ok
+}

--- a/runtime/go/prompty/providers/providers_test.go
+++ b/runtime/go/prompty/providers/providers_test.go
@@ -1,0 +1,202 @@
+package providers
+
+import (
+	"encoding/json"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	prompty "prompty/model"
+)
+
+func loadAgent(t *testing.T, data map[string]interface{}) prompty.Agent {
+	t.Helper()
+	agent, err := prompty.LoadAgent(data, prompty.NewLoadContext())
+	if err != nil {
+		t.Fatalf("LoadAgent failed: %v", err)
+	}
+	return agent
+}
+
+func textMessage(role, text string) prompty.Message {
+	return prompty.Message{
+		Role:  prompty.Role(role),
+		Parts: []interface{}{prompty.TextPart{Kind: "text", Value: text}},
+	}
+}
+
+func TestRegistryRoundTrip(t *testing.T) {
+	// Isolate from any global registration by using unique keys.
+	RegisterExecutor("test-exec", nil)
+	if _, ok := GetExecutor("test-exec"); !ok {
+		t.Fatal("expected registered executor key to be present")
+	}
+	if _, ok := GetExecutor("missing-key"); ok {
+		t.Fatal("expected missing key to be absent")
+	}
+	RegisterProcessor("test-proc", nil)
+	if _, ok := GetProcessor("test-proc"); !ok {
+		t.Fatal("expected registered processor key to be present")
+	}
+}
+
+func TestBuildInputChat(t *testing.T) {
+	agent := loadAgent(t, map[string]interface{}{
+		"name": "t",
+		"model": map[string]interface{}{
+			"id":      "gpt-4",
+			"options": map[string]interface{}{"temperature": 0.5},
+		},
+		"tools": []interface{}{
+			map[string]interface{}{
+				"name":        "get_weather",
+				"kind":        "function",
+				"description": "Get weather",
+				"parameters": []interface{}{
+					map[string]interface{}{"name": "location", "kind": "string", "required": true},
+				},
+			},
+		},
+		"outputs": []interface{}{
+			map[string]interface{}{"name": "answer", "kind": "string", "required": true},
+		},
+	})
+
+	input := BuildInput(agent, []prompty.Message{textMessage("user", "hi")}, "openai")
+	if input["provider"] != "openai" {
+		t.Fatalf("provider = %v", input["provider"])
+	}
+	if input["model_id"] != "gpt-4" {
+		t.Fatalf("model_id = %v", input["model_id"])
+	}
+
+	body, err := prompty.BuildWireRequest(input)
+	if err != nil {
+		t.Fatalf("BuildWireRequest: %v", err)
+	}
+	if body["model"] != "gpt-4" {
+		t.Fatalf("body model = %v", body["model"])
+	}
+	if _, ok := body["tools"]; !ok {
+		t.Fatal("expected tools in wire body")
+	}
+	if _, ok := body["response_format"]; !ok {
+		t.Fatal("expected response_format in wire body")
+	}
+	msgs, ok := body["messages"].([]interface{})
+	if !ok || len(msgs) != 1 {
+		t.Fatalf("expected 1 message, got %v", body["messages"])
+	}
+}
+
+func TestMessagesToWireMediaAndMetadata(t *testing.T) {
+	mt := "image/png"
+	messages := []prompty.Message{
+		{
+			Role: prompty.Role("user"),
+			Parts: []interface{}{
+				prompty.TextPart{Kind: "text", Value: "describe"},
+				prompty.ImagePart{Kind: "image", Source: "b64data", MediaType: &mt},
+			},
+			Metadata: map[string]interface{}{"k": "v"},
+		},
+	}
+	wire := messagesToWire(messages)
+	m := wire[0].(map[string]interface{})
+	if m["metadata"] == nil {
+		t.Fatal("expected metadata preserved")
+	}
+	content := m["content"].([]interface{})
+	img := content[1].(map[string]interface{})
+	if img["kind"] != "image" || img["value"] != "b64data" || img["mediaType"] != "image/png" {
+		t.Fatalf("image part mapped incorrectly: %v", img)
+	}
+}
+
+func TestResolveConnectionApiKey(t *testing.T) {
+	agent := loadAgent(t, map[string]interface{}{
+		"name": "t",
+		"model": map[string]interface{}{
+			"id": "gpt-4",
+			"connection": map[string]interface{}{
+				"kind":     "key",
+				"endpoint": "https://example.com",
+				"apiKey":   "sk-abc",
+			},
+		},
+	})
+	conn := ResolveConnection(agent)
+	if conn.Kind != "key" || conn.Endpoint != "https://example.com" || conn.APIKey != "sk-abc" {
+		t.Fatalf("resolved connection = %+v", conn)
+	}
+}
+
+func TestResolveConnectionEmpty(t *testing.T) {
+	agent := loadAgent(t, map[string]interface{}{"name": "t", "model": map[string]interface{}{"id": "gpt-4"}})
+	conn := ResolveConnection(agent)
+	if conn.Endpoint != "" || conn.APIKey != "" {
+		t.Fatalf("expected empty connection, got %+v", conn)
+	}
+}
+
+func TestFormatChatToolMessages(t *testing.T) {
+	text := "thinking"
+	calls := []prompty.ToolCall{{Id: "c1", Name: "get_weather", Arguments: `{"location":"NYC"}`}}
+	msgs := FormatChatToolMessages(calls, []string{"72F"}, &text)
+	if len(msgs) != 2 {
+		t.Fatalf("expected 2 messages, got %d", len(msgs))
+	}
+	if string(msgs[0].Role) != "assistant" {
+		t.Fatalf("first message role = %s", msgs[0].Role)
+	}
+	if _, ok := msgs[0].Metadata["tool_calls"]; !ok {
+		t.Fatal("assistant message missing tool_calls metadata")
+	}
+	if string(msgs[1].Role) != "tool" {
+		t.Fatalf("second message role = %s", msgs[1].Role)
+	}
+	if msgs[1].Metadata["tool_call_id"] != "c1" || msgs[1].Metadata["name"] != "get_weather" {
+		t.Fatalf("tool message metadata = %v", msgs[1].Metadata)
+	}
+}
+
+func TestPostJSON(t *testing.T) {
+	var gotBody map[string]interface{}
+	var gotAuth string
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotAuth = r.Header.Get("Authorization")
+		data, _ := io.ReadAll(r.Body)
+		_ = json.Unmarshal(data, &gotBody)
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"ok":true}`))
+	}))
+	defer srv.Close()
+
+	resp, err := PostJSON(srv.URL, map[string]string{"Authorization": "Bearer x"}, map[string]interface{}{"a": 1})
+	if err != nil {
+		t.Fatalf("PostJSON: %v", err)
+	}
+	if resp["ok"] != true {
+		t.Fatalf("response = %v", resp)
+	}
+	if gotAuth != "Bearer x" {
+		t.Fatalf("auth header = %q", gotAuth)
+	}
+	if gotBody["a"] != float64(1) {
+		t.Fatalf("request body = %v", gotBody)
+	}
+}
+
+func TestPostJSONErrorStatus(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusBadRequest)
+		_, _ = w.Write([]byte(`{"error":"bad"}`))
+	}))
+	defer srv.Close()
+
+	_, err := PostJSON(srv.URL, nil, map[string]interface{}{})
+	if err == nil {
+		t.Fatal("expected error on non-2xx status")
+	}
+}

--- a/schema/scripts/normalize-typra-output.mjs
+++ b/schema/scripts/normalize-typra-output.mjs
@@ -62,14 +62,22 @@ function trimTrailingWhitespace(root) {
   }
 }
 
-// Workaround for upstream typra emitter bug (sethjuarez/typra#260): the Swift
-// driver regenerates Package.swift without the main target's
-// `resources: [.process("Resources")]` stanza. The PromptyModel target bundles
-// Resources (model_capabilities.json plus vector fixtures) that `swift test`
-// loads via Bundle.module, so a regenerate silently breaks resource loading and
-// trips the regen-drift gate until the stanza is re-added by hand. Re-inject it
-// deterministically after every regenerate. Remove this once #260 ships and the
-// emitter preserves the stanza natively.
+// Re-inject the main PromptyModel target's `resources: [.process("Resources")]`
+// stanza, which the typra Swift driver drops every time it regenerates
+// Package.swift. The main target bundles Resources (model_capabilities.json)
+// that the *public* `Discovery` API loads via `Bundle.module` from production
+// source (Sources/PromptyModel/Discovery.swift) — not just tests — so the
+// stanza must live on the main target.
+//
+// This is NOT replaceable by the emitter's `test-resources` option (typra#260,
+// shipped in 1.0.1). That option only attaches resources to the *test* target.
+// Verified empirically: moving Resources to the test target makes `swift test`
+// fail to compile the main target with "type 'Bundle' has no member 'module'",
+// because SwiftPM only synthesizes `Bundle.module` for a target that owns
+// resources. The emitter exposes no main-target resources option, so this hand
+// re-injection remains load-bearing. Fully removing it requires relocating
+// Discovery + the capabilities resource into a package the emitter does not
+// regenerate (tracked with the Swift split-package work in #487).
 function restoreSwiftPackageResources(packagePath) {
   if (!existsSync(packagePath)) {
     return;

--- a/schema/scripts/normalize-typra-output.mjs
+++ b/schema/scripts/normalize-typra-output.mjs
@@ -12,7 +12,6 @@ if (existsSync(manifestPath)) {
 
 trimEmptyPythonGeneratedTests(join("..", "runtime", "python", "prompty", "tests", "model"));
 trimTrailingWhitespace(join("..", "runtime", "go", "prompty", "model"));
-restoreGoModelImport(join("..", "runtime", "go", "prompty", "model"));
 restoreSwiftPackageResources(join("..", "runtime", "swift", "prompty-model", "Package.swift"));
 
 // Note: the dead `if ctx == nil { ctx = NewLoadContext() }` guard in leaf Go
@@ -59,49 +58,6 @@ function trimTrailingWhitespace(root) {
       .join("\n");
     if (normalized !== content) {
       writeFileSync(path, normalized);
-    }
-  }
-}
-
-// Workaround for upstream typra emitter bug (sethjuarez/typra#262): the Go test
-// emitter prunes the `prompty/model` import from generated external-test files
-// (`package prompty_test`). The Go module is `prompty` and the model package is
-// declared `package prompty` (folder `model`), so `import "prompty/model"` binds
-// the identifier `prompty` — which the tests use via `prompty.LoadAgent(...)`,
-// `prompty.NewLoadContext()`, etc. The emitter's import-usage detection keys on
-// the path-derived segment (`model.`) instead of the real package name
-// (`prompty.`), decides the import is unused, and drops it — breaking
-// `go vet`/`go test` with "undefined: prompty". Re-inject the import after every
-// regenerate for test files that reference the `prompty.` qualifier but lack it.
-// Remove this once #262 ships and the emitter preserves the import natively.
-function restoreGoModelImport(root) {
-  if (!existsSync(root)) {
-    return;
-  }
-  for (const entry of readdirSync(root)) {
-    const path = join(root, entry);
-    if (statSync(path).isDirectory()) {
-      restoreGoModelImport(path);
-      continue;
-    }
-    if (!path.endsWith("_test.go")) {
-      continue;
-    }
-    const content = readFileSync(path, "utf8");
-    if (
-      !content.includes("package prompty_test") ||
-      content.includes('"prompty/model"') ||
-      !/\bprompty\.[A-Z]/u.test(content)
-    ) {
-      continue;
-    }
-    // Append the local import as a trailing group inside the first import block.
-    const patched = content.replace(
-      /import \(\n([\s\S]*?)\n\)/u,
-      (_match, body) => `import (\n${body}\n\n\t"prompty/model"\n)`,
-    );
-    if (patched !== content) {
-      writeFileSync(path, patched);
     }
   }
 }


### PR DESCRIPTION
## Summary

Part of the conformance-waiver-removal effort. This branch lands two completed, verified issues and documents findings on the rest. **No issues are auto-closed** (`Refs`, not `Closes`) — closing is left to review.

### Committed & verified

- **Refs #485** — remove obsolete normalize-script emitter workarounds now that typra 1.0.1 shipped the upstream fixes.
  - `fix(#485)`: delete the dead `restoreGoModelImport` call + function — Go test imports are preserved natively by the emitter (typra#262).
  - `docs(#485)`: correct the `restoreSwiftPackageResources` rationale.
  - Verified: regen-drift gate stays green.
- **Refs #490** — add Go provider implementations (openai, anthropic, foundry): the only runtime that previously lacked a provider/executor package.
  - Verified: `go build`, `go vet`, `go test` all green.

### Investigated → documented (no code in this PR)

- **#479** (TS 5→7) — reproduced the tsup/rollup-plugin-dts crash on TS7; upstream gates unmet. Stays blocked.
- **#487** (Swift real-pipeline vectors) — the `harness-test-dir` relocation is mechanically proven, but a clean 0-waiver relocation is blocked on `run`/`runTurn` observability (vectors assert a rich projection produced only by the model-level `AgentLoopEngine`; the SDK production `turn()` exposes only the final result). Needs a maintainer design decision — see issue comment for full evidence.
- **#488** (async Swift wiring) — the Swift `sync:` adapters wrap genuinely-sync reference engines (honest, not stand-ins); entangled with #487 and blocked on the same decision. Python/TS already satisfy it.

### Deferred (environment/scope)

- **#489** — Java unbuildable in this environment (mvn/gradle missing), so the cross-runtime DoD can't be verified.
- **#91** — no MSBuild/VS SDK to build/verify a VSIX; large greenfield, out of scope for this effort.

## Test plan

- `schema`: regen (`npm run generate`) produces zero drift with the `restoreGoModelImport` workaround removed.
- `runtime/go`: `go build ./... && go vet ./... && go test ./...` green.