### PR TITLE
Fix broken @prompty/core npm release (ship 0.1.6)

### DIFF
--- a/.github/workflows/prompty-ts-release.yml
+++ b/.github/workflows/prompty-ts-release.yml
@@ -41,6 +41,7 @@ jobs:
           registry-url: https://registry.npmjs.org
       - run: npm install -g npm@11.6.4
       - run: npm ci
+      - run: npm run build
       - name: Verify package version
-        run: test "$(node -p "require('./package.json').version")" = "0.1.5"
+        run: test "$(node -p "require('./package.json').version")" = "0.1.6"
       - run: npm publish --provenance --access public

--- a/runtime/promptyjs/package.json
+++ b/runtime/promptyjs/package.json
@@ -1,17 +1,18 @@
 {
   "name": "@prompty/core",
-  "version": "0.1.5",
+  "version": "0.1.6",
   "description": "Prompty core package",
   "main": "./dist/index.js",
   "module": "./dist/index.mjs",
   "types": "./dist/index.d.ts",
   "files": [
-    "/dist"
+    "dist"
   ],
   "scripts": {
     "test": "jest",
     "test:watch": "jest --watch",
     "build": "tsup src/index.ts --format cjs,esm --dts",
+    "prepublishOnly": "npm run build",
     "dev": "npm run build -- --watch",
     "publish-packages": "turbo run build lint test && changeset version && changeset publish --access public"
   },


### PR DESCRIPTION
Fixes the broken `@prompty/core@0.1.5` npm release by shipping a corrected **0.1.6**.

## Problem
`@prompty/core@0.1.5` published a tarball containing only `package.json` + `README.md` — no `dist/` — so `main: ./dist/index.js` resolves to nothing and consumers cannot import it. npm versions are immutable, so this ships 0.1.6.

## Root causes
1. `runtime/promptyjs/package.json` used `"files": ["/dist"]` (leading-slash glob).
2. `.github/workflows/prompty-ts-release.yml` built only in the `test` job; the separate `publish` job never ran `npm run build`, so `dist/` was absent at pack time.

## Changes
- `package.json`: `files: ["/dist"]` -> `["dist"]`; version `0.1.5` -> `0.1.6`; add `prepublishOnly: "npm run build"`.
- `prompty-ts-release.yml`: add `npm run build` in the publish job (after `npm ci`, before `npm publish`); version guard `0.1.5` -> `0.1.6`.

## Verification
`npm pack --dry-run` for 0.1.6 now includes all build output (`dist/index.js` 16.8kB, `dist/index.mjs` 14.9kB, `dist/index.d.ts`, `dist/index.d.mts`). Tests: 20/20 pass.

## Follow-up
After merge: run the `Legacy v1 @prompty/core Release` workflow to publish 0.1.6, then `npm deprecate @prompty/core@0.1.5`.