### PR TITLE
Release versioning proposal + live provider capability guard reference

### DIFF
--- a/release-versioning-proposal.md
+++ b/release-versioning-proposal.md
@@ -1,0 +1,297 @@
+# Prompty Release & Versioning Proposal (post-beta)
+
+**Status:** Draft for review · Author: session with @sethjuarez · Date: 2026-08-23
+**Decision needed:** Adopt (or amend) before cutting `2.0.0` stable.
+
+---
+
+## 1. Problem statement
+
+Prompty is **one spec** (`.prompty` file format) with **many implementations**
+(python, typescript, csharp, rust, java, swift). The current release process:
+
+- Version bump is **manual and discretionary** (`scripts/release.py --bump minor`);
+  the human decides major/minor/patch — nothing ties the bump to what actually changed.
+- The Python release script **pushes commit + tag directly to `main`** locally, then the
+  tag triggers PyPI publish. No review gate, no provenance on the version decision.
+- Every runtime versions **independently already** (tag namespaces `python/`, `typescript/`,
+  `csharp/`, `rust/`), but there is **no documented contract** for which runtime version
+  supports which `.prompty` format version.
+- No automated changelog; release notes are ad hoc.
+
+What's **already good** (keep it):
+
+- Per-runtime tag namespacing (`python/2.0.0b3`, `typescript/*`, `csharp/*`, `rust/*`).
+- A "verify tag matches source version" guard in **every** publish workflow.
+- OIDC / trusted publishing (PyPI, npm provenance, NuGet OIDC). Rust still uses a token secret.
+
+---
+
+## 2. Core recommendation
+
+Adopt a **two-layer versioning model**:
+
+1. **Format version** — versions the `.prompty` schema itself (the compatibility currency).
+2. **Runtime versions** — each language package versions **independently** via
+   Conventional Commits + automated release PRs, and **declares which format version(s)
+   it supports**.
+
+This keeps per-package versions **honest** (a bump means that package changed) while giving
+users **one stable answer** to "are these compatible?" — they compare against the format
+version, not against each other.
+
+> Rejected alternative — **lockstep** (all runtimes share one number): produces hollow
+> "no changes" releases, couples cadence to the slowest runtime, and makes patch numbers lie.
+> Only worth it if we want to market "Prompty 2.3" as a single product line. We can revisit,
+> but independent is the lower-friction match for the repo as it exists today.
+
+---
+
+## 3. Format version contract
+
+### 3.1 Scheme
+
+- The `.prompty` file format gets its own version, **`format: N`** (a single integer, or
+  `MAJOR.MINOR` if we want additive vs breaking granularity). Source of truth: the in-repo
+  TypeSpec/Typra model + `Prompty.yaml` JSON Schema.
+- **Bump MAJOR** when a valid old file stops loading, or field semantics change incompatibly.
+- **Bump MINOR** (if we use `MAJOR.MINOR`) for additive, backward-compatible fields.
+- The format version is **independent of any runtime's semver**. Runtime `2.x` and `3.x`
+  can both speak format `2`.
+
+### 3.2 How files declare it (optional, additive)
+
+Today `.prompty` files carry no `format:` marker and the loader injects `kind: prompt`.
+Proposed: allow an **optional** top-level `format:` key in frontmatter. When absent, the
+loader assumes the current default and may emit an info/deprecation note — matching the
+existing legacy-migration philosophy in the loader. This stays backward compatible.
+
+### 3.3 Compatibility matrix (lives in `/docs` + each package README)
+
+| Runtime pkg      | Version line | Supports format |
+| ---------------- | ------------ | --------------- |
+| `prompty` (py)   | `2.x`        | `2`             |
+| `@prompty/core`  | `2.x`        | `2`             |
+| `Prompty.Core`   | `2.x`        | `2`             |
+| `prompty` (rust) | `2.x`        | `2`             |
+
+Rule of thumb: a runtime MAJOR bump is required only when it **drops** support for a format
+version it previously accepted — not merely because its own API changed.
+
+---
+
+## 4. Semantic versioning rules per runtime
+
+Standard SemVer, with the public contract defined as **(a) the package's public API** and
+**(b) the set of `.prompty` format versions it accepts**:
+
+- **MAJOR** — remove/rename public API, or drop a previously-supported format version.
+- **MINOR** — additive API, new provider/tool support, accept a new format version.
+- **PATCH** — bug fixes, perf, docs, internal refactors, security fixes (like PR #502).
+
+Exit beta by cutting **`2.0.0`** for each runtime that's ready; runtimes not ready stay on
+their own prerelease line (PEP 440 `bN` / npm `-alpha`, etc.). Independence means Swift can
+still be `b`-something while Python is `2.0.0`.
+
+---
+
+## 5. Automation: Conventional Commits + release-please
+
+### 5.1 Commit convention
+
+Adopt **Conventional Commits** (already partially in use — e.g. `chore(python): release …`,
+`fix: avoid shell interpretation …`). Scope = runtime:
+
+```
+feat(python): add anthropic provider          → minor
+fix(rust): handle empty tool list             → patch
+feat(ts)!: rename load() to loadPrompty()      → major (! or BREAKING CHANGE:)
+chore(python): …                               → no release
+docs: …                                        → no release
+```
+
+Enforce with a lightweight commit-lint check in `hygiene.yml` (warn first, block later).
+
+### 5.2 release-please, one config per runtime
+
+Use **googleapis/release-please** in **manifest mode** so each runtime is its own release
+"package" with its own version, changelog, and release PR:
+
+- On merge to `main`, release-please opens/updates a **release PR per runtime** that has
+  unreleased Conventional Commits: bumps the version file, updates `CHANGELOG.md`.
+- Merging that release PR creates the git tag in the runtime's existing namespace
+  (`python/2.1.0`, `typescript/2.1.0`, …).
+- The **existing publish workflows fire unchanged** — they already trigger on those tags and
+  already verify tag == source version. release-please just replaces the manual
+  `scripts/release.py` bump+push step.
+
+Sketch `release-please-config.json`:
+
+```json
+{
+  "separate-pull-requests": true,
+  "tag-separator": "/",
+  "packages": {
+    "runtime/python/prompty": {
+      "release-type": "python",
+      "component": "python",
+      "version-file": "prompty/_version.py"
+    },
+    "runtime/typescript": {
+      "release-type": "node",
+      "component": "typescript"
+    },
+    "runtime/csharp": {
+      "release-type": "simple",
+      "component": "csharp",
+      "extra-files": ["Prompty.Core/Prompty.Core.csproj"]
+    },
+    "runtime/rust": {
+      "release-type": "rust",
+      "component": "rust"
+    }
+  }
+}
+```
+
+(Exact `version-file` / `extra-files` wiring needs a validation pass against each runtime's
+version source — noted as open work, not settled here.)
+
+### 5.3 What `scripts/release.py` becomes
+
+- Retire it as the primary path (release-please owns bump + tag).
+- Optionally keep a thin **`--dry-run` preview** / manual-escape-hatch version, but drop the
+  `shell=True` invocation entirely (PR #502 is the interim fix; the real fix is not shelling
+  out for releases at all).
+
+---
+
+## 6. Migration plan (incremental, low-risk)
+
+1. **Pilot on Python** (it's furthest along + the one we're actively touching):
+   - Add Conventional Commit linting (warn-only).
+   - Add release-please for `runtime/python/prompty` only.
+   - Keep manual script available as fallback for one or two releases.
+2. **Publish the format-version contract doc** + compat matrix; add optional `format:` key
+   support to the loader (additive, backward compatible).
+3. **Cut `2.0.0` stable for Python** via the new flow to prove it end-to-end.
+4. **Roll out** release-please configs to ts / csharp / rust (their publish workflows already
+   accept the tags).
+5. **Retire** `scripts/release.py` shell path once every runtime is on release-please.
+6. Standardize Rust onto a trusted-publishing token story consistent with the others (cleanup).
+
+---
+
+## 7. Open questions to noodle on
+
+1. Format version granularity: single integer `format: 2` vs `MAJOR.MINOR` (`2.1`)?
+2. Do we ever want a **marketing** umbrella version ("Prompty 2") decoupled from package
+   numbers, for docs/site messaging?
+3. Should the optional `format:` key eventually become **required** at a future format MAJOR?
+4. Runtimes at different maturity (swift/java still early) — do they exit beta on their own
+   timeline, or do we gate the `2.0.0` announcement on a minimum set?
+5. Changelog aggregation: per-runtime `CHANGELOG.md` only, or also a root aggregated view?
+6. Commit-lint: warn-only indefinitely, or hard-block after a grace period?
+
+---
+
+## 9. Live provider conformance vectors (cross-runtime)
+
+Separate but related idea that came up while reviewing the release plan: extend the
+existing `@vector` conformance system to cover **live provider behavior**, so every runtime
+exercises real OpenAI / Anthropic / Foundry endpoints in CI — and self-waives when keys
+are absent.
+
+### 9.1 Why this is the right layer
+
+The repo already has a cross-runtime vector system:
+
+- `@vector` cases are declared once in the **TypeSpec schema** (source of truth).
+- **Typra emits `test_vector_conformance.py` into every runtime** automatically — so a
+  vector added once shows up in py / ts / csharp / rust / … with no per-language work.
+- Each runtime hand-authors `vector_adapters.py`, registering
+  `VECTOR_ADAPTERS["Contract.operation"] = {invoke, normalize}` as the single seam.
+- The harness already resolves `$env`, `$file`, `$json` refs in vector input — so
+  **credential injection via `$env` already exists** (reads `os.environ`, returns `""`
+  when missing).
+
+So "emitted in every language → shows up in CI" is a property we get for free.
+
+### 9.2 Key insight — structure is the contract, not content
+
+Live LLM responses are non-deterministic, so we do **not** assert on content. We assert that
+a live response **maps into a schema-valid instance of the canonical types** — the same kind
+of structural assertion the offline vectors already make, just fed by a live call instead of
+a fixture. The adapter reduces the live response to **shape, not values**.
+
+| Live vector       | Structural assertion (not content)                                              |
+| ----------------- | ------------------------------------------------------------------------------- |
+| chat              | normalizes to `Message`, `role=assistant`, `content` non-empty, `finishReason ∈ enum` |
+| tool call         | yields a `ToolCall` with `name` + `arguments` parsing as a JSON object of the declared shape |
+| embedding         | float vector of the model's expected dimensionality (structural + deterministic) |
+| structured output | response JSON validates against the declared `outputs` schema                    |
+| streaming         | chunks reassemble into the same structural shape as the non-streamed response   |
+
+No fuzzy matchers, no golden content, no per-model brittleness — the projection is "conforms
+to the type," which is exactly what the schema already defines. Assertions stay exact-match
+at the harness level.
+
+### 9.3 Skip semantics — a new, principled axis
+
+Today the harness **never skips silently**: a missing adapter is a hard fail; `VECTOR_WAIVERS`
+are explicit and reasoned. Live vectors add a **third, distinct axis**:
+
+- **waiver** — this runtime does not implement the behavior (existing).
+- **credentials-absent** — environment has no key → legitimate `pytest.skip`
+  (`"credentials absent: ANTHROPIC_API_KEY"`). Environmental, not a conformance dodge. **New.**
+- **failure** — implemented, keys present, wrong structure.
+
+Mechanism: add a `requires: [ENV_KEYS]` field to live vectors. The harness checks presence and
+skips as *credentials-absent* when missing. Consequence: the suite lights up wherever secrets
+exist (each runtime's CI) and self-waives everywhere else — including **fork PRs**, which can't
+see secrets. That fork-PR behavior is a feature, not a gap.
+
+### 9.4 Shape of the work
+
+1. Define a live-conformance contract in the schema (e.g. `LiveChatConformance.complete`,
+   `LiveEmbeddingConformance.embed`, …) with `requires` credential lists and **structural**
+   `expected` shapes.
+2. Typra emits the vectors into every runtime (no per-language authoring of the cases).
+3. Each runtime authors one adapter per live operation: call the provider, normalize the
+   response to its structural shape.
+4. Add a `requires`/credentials-absent skip axis to the harness (schema + emitter change,
+   applied uniformly across runtimes).
+5. Add an **opt-in CI job per runtime** wired to that runtime's secrets/environment. Default
+   PR checks stay offline; the live job runs on `main` / release branches (and skips cleanly
+   without secrets).
+
+### 9.5 Costs / caveats
+
+- Live vectors in **every** runtime's CI multiply API cost by the number of runtimes and add
+  flakiness — structural (not content) assertions are what keep them stable.
+- Secrets must be provisioned per runtime CI environment; keep them out of fork-PR context.
+- Ties into §3: these vectors also become the enforcement mechanism for the **format-version
+  contract** — "does runtime X actually accept format N" can be a vector.
+
+### 9.6 Open questions
+
+1. One live contract per API type (chat/embedding/image/tool/structured/streaming), or one
+   umbrella `LiveConformance` with an operation per shape?
+2. Where do live vectors run — every push to `main`, nightly, or pre-release only (cost)?
+3. Do we assert model-specific structural facts (e.g. embedding dimensionality) per provider,
+   or keep vectors provider-agnostic and let the adapter supply expected dims?
+4. Should `credentials-absent` skips be **reported** (surfaced in a summary) so we can see which
+   providers a given CI env actually covered, rather than silently green?
+
+---
+
+## 10. TL;DR
+
+- Keep **independent** runtime versions; add an explicit **format-version contract** as the
+  real compatibility currency.
+- Move bumps from manual `scripts/release.py` → **Conventional Commits + release-please**
+  (release PRs, auto changelog), reusing the **existing per-runtime tag → publish** workflows.
+- Exit beta by cutting **`2.0.0`** per runtime, piloting on Python first.
+- Extend the `@vector` system with **live provider conformance vectors** that assert
+  **structure, not content**, emitted into every runtime and self-waiving as
+  *credentials-absent* when keys are missing.

--- a/runtime/python/prompty/tests/model/test_capability_guard_reference.py
+++ b/runtime/python/prompty/tests/model/test_capability_guard_reference.py
@@ -1,0 +1,272 @@
+"""Reference tests for the live-provider capability guard seam.
+
+These tests pin the Python side of the cross-runtime capability guard contract
+shipped in the Typra emitter (>= 1.1.0). They exercise:
+
+* the ``VECTOR_CAPABILITIES`` predicates in ``vector_adapters`` (present/absent),
+* a faithful LOCAL REPLICA of the emitter's two-pass guard so the skip/hard-fail
+  semantics are verified without waiting for a regenerated harness, and
+* the structure-not-content ``_live_chat_normalize`` projection.
+
+The generated harness (``test_vector_conformance.py``) only invokes the guard
+once a schema vector declares ``requires`` AND the emitter pin is bumped to
+1.1.0. Until then, ``_reference_guard`` below stands in for that emitted logic so
+the semantics stay locked and testable.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+from pathlib import Path
+from typing import Any
+from unittest.mock import MagicMock
+
+import pytest
+from _pytest.outcomes import Skipped
+
+# Load the sibling adapter module by path so the test is independent of sys.path
+# quirks (tests/model has no __init__.py; the harness itself loads it by path).
+_SPEC = importlib.util.spec_from_file_location("vector_adapters_ref", Path(__file__).with_name("vector_adapters.py"))
+assert _SPEC is not None and _SPEC.loader is not None
+va = importlib.util.module_from_spec(_SPEC)
+_SPEC.loader.exec_module(va)
+
+
+# ---------------------------------------------------------------------------
+# Local replica of the emitted guard (mirrors the Typra >= 1.1.0 contract).
+# ---------------------------------------------------------------------------
+
+_UNKNOWN_TOKEN_MESSAGE = (
+    'No capability predicate registered for requirement token "{token}". '
+    'Register VECTOR_CAPABILITIES["{token}"] in the module referenced by '
+    "'vector-adapter-path'. @vector conformance never skips silently."
+)
+
+
+def _reference_guard(requires: list[str], context: dict, capabilities: dict[str, Any]) -> None:
+    """Two-pass guard identical in spirit to the emitted harness code.
+
+    Pass 1 (registration): every token must be registered, else HARD failure.
+    Pass 2 (availability): first falsy predicate -> ``pytest.skip`` with the
+    canonical reason. Both passes walk ``requires`` in author order, never sorted.
+    """
+    for token in requires:
+        if token not in capabilities:
+            raise AssertionError(_UNKNOWN_TOKEN_MESSAGE.format(token=token))
+    for token in requires:
+        if not capabilities[token](context):
+            pytest.skip(f"requirement unavailable: {token}")
+
+
+def _context(**overrides: Any) -> dict:
+    base: dict[str, Any] = {
+        "contract": "LiveChatConformance",
+        "operation": "complete",
+        "vector": {},
+        "provider": "openai",
+        "targetApi": None,
+        "doubles": {},
+        "baseDir": ".",
+        "resolveInput": lambda value: value,
+    }
+    base.update(overrides)
+    return base
+
+
+# ---------------------------------------------------------------------------
+# VECTOR_CAPABILITIES registration
+# ---------------------------------------------------------------------------
+
+
+class TestCapabilitiesTable:
+    def test_expected_tokens_registered(self) -> None:
+        caps = va.VECTOR_CAPABILITIES
+        for token in (
+            "provider:openai",
+            "provider:anthropic",
+            "provider:azure",
+            "provider:foundry",
+            "entra:foundry-project",
+            "var:live-enabled",
+        ):
+            assert token in caps, f"missing capability token: {token}"
+            assert callable(caps[token])
+
+    def test_tokens_follow_grammar(self) -> None:
+        import re
+
+        pattern = re.compile(r"^[a-z0-9][a-z0-9-]*:[a-z0-9][a-z0-9-]*$")
+        for token in va.VECTOR_CAPABILITIES:
+            assert pattern.match(token), f"token violates namespace:name grammar: {token}"
+
+
+# ---------------------------------------------------------------------------
+# Individual predicate behavior (absent by default, present when env is set)
+# ---------------------------------------------------------------------------
+
+
+class TestProviderPredicates:
+    def test_openai_absent_then_present(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.delenv("OPENAI_API_KEY", raising=False)
+        assert va._cap_provider_openai(_context()) is False
+        monkeypatch.setenv("OPENAI_API_KEY", "sk-test")
+        assert va._cap_provider_openai(_context()) is True
+
+    def test_anthropic_absent_then_present(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.delenv("ANTHROPIC_API_KEY", raising=False)
+        assert va._cap_provider_anthropic(_context()) is False
+        monkeypatch.setenv("ANTHROPIC_API_KEY", "sk-ant-test")
+        assert va._cap_provider_anthropic(_context()) is True
+
+    def test_azure_requires_all_three(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.delenv("AZURE_OPENAI_API_KEY", raising=False)
+        monkeypatch.delenv("AZURE_OPENAI_ENDPOINT", raising=False)
+        monkeypatch.delenv("AZURE_OPENAI_CHAT_DEPLOYMENT", raising=False)
+        assert va._cap_provider_azure(_context()) is False
+
+        monkeypatch.setenv("AZURE_OPENAI_API_KEY", "key")
+        assert va._cap_provider_azure(_context()) is False  # endpoint + deployment still missing
+        monkeypatch.setenv("AZURE_OPENAI_ENDPOINT", "https://x.openai.azure.com/")
+        assert va._cap_provider_azure(_context()) is False  # deployment still missing
+        monkeypatch.setenv("AZURE_OPENAI_CHAT_DEPLOYMENT", "gpt-4o-mini")
+        assert va._cap_provider_azure(_context()) is True
+
+    def test_var_live_enabled_toggle(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.delenv("PROMPTY_LIVE_VECTORS", raising=False)
+        assert va._cap_var_live_enabled(_context()) is False
+        for truthy in ("1", "true", "TRUE", "yes", "on"):
+            monkeypatch.setenv("PROMPTY_LIVE_VECTORS", truthy)
+            assert va._cap_var_live_enabled(_context()) is True
+        for falsy in ("0", "false", "no", "off", ""):
+            monkeypatch.setenv("PROMPTY_LIVE_VECTORS", falsy)
+            assert va._cap_var_live_enabled(_context()) is False
+
+    def test_entra_probe_false_without_endpoint(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        # No endpoint anywhere -> probe short-circuits to False without needing
+        # azure-identity or a signed-in identity.
+        monkeypatch.delenv("AZURE_OPENAI_ENDPOINT", raising=False)
+        assert va._cap_entra_foundry_project(_context(vector={})) is False
+
+
+# ---------------------------------------------------------------------------
+# Guard semantics (via the local replica)
+# ---------------------------------------------------------------------------
+
+
+class TestGuardSemantics:
+    def test_unknown_token_hard_fails(self) -> None:
+        with pytest.raises(AssertionError) as exc:
+            _reference_guard(["bogus:token"], _context(), va.VECTOR_CAPABILITIES)
+        message = str(exc.value)
+        assert 'No capability predicate registered for requirement token "bogus:token".' in message
+        assert "@vector conformance never skips silently." in message
+
+    def test_absent_capability_skips_with_canonical_reason(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.delenv("OPENAI_API_KEY", raising=False)
+        with pytest.raises(Skipped) as exc:
+            _reference_guard(["provider:openai"], _context(), va.VECTOR_CAPABILITIES)
+        assert exc.value.msg == "requirement unavailable: provider:openai"
+
+    def test_present_capability_proceeds(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setenv("OPENAI_API_KEY", "sk-test")
+        # No skip, no error -> returns None.
+        assert _reference_guard(["provider:openai"], _context(), va.VECTOR_CAPABILITIES) is None
+
+    def test_author_order_first_falsy_wins(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        # Both absent; the FIRST token in author order must be the skip reason.
+        monkeypatch.delenv("PROMPTY_LIVE_VECTORS", raising=False)
+        monkeypatch.delenv("OPENAI_API_KEY", raising=False)
+        with pytest.raises(Skipped) as exc:
+            _reference_guard(["var:live-enabled", "provider:openai"], _context(), va.VECTOR_CAPABILITIES)
+        assert exc.value.msg == "requirement unavailable: var:live-enabled"
+
+    def test_registration_pass_precedes_availability(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        # An unknown token AFTER an absent-but-known token must still HARD fail:
+        # registration (pass 1) runs fully before availability (pass 2).
+        monkeypatch.delenv("OPENAI_API_KEY", raising=False)
+        with pytest.raises(AssertionError):
+            _reference_guard(["provider:openai", "bogus:token"], _context(), va.VECTOR_CAPABILITIES)
+
+
+# ---------------------------------------------------------------------------
+# Structure-not-content normalization
+# ---------------------------------------------------------------------------
+
+
+def _openai_response(role: str = "assistant", content: str = "Hello", finish: str = "stop") -> Any:
+    message = MagicMock()
+    message.role = role
+    message.content = content
+    choice = MagicMock()
+    choice.message = message
+    choice.finish_reason = finish
+    response = MagicMock()
+    response.choices = [choice]
+    return response
+
+
+class TestLiveChatNormalize:
+    def test_openai_shape_reduces_to_structure(self) -> None:
+        result = va._live_chat_normalize(_openai_response(), _context())
+        assert result == {
+            "role": "assistant",
+            "contentNonEmpty": True,
+            "finishReasonInEnum": True,
+        }
+
+    def test_empty_content_flags_false(self) -> None:
+        result = va._live_chat_normalize(_openai_response(content="   "), _context())
+        assert result["contentNonEmpty"] is False
+
+    def test_finish_reason_outside_enum_flags_false(self) -> None:
+        result = va._live_chat_normalize(_openai_response(finish="explode"), _context())
+        assert result["finishReasonInEnum"] is False
+
+    @pytest.mark.parametrize(
+        "finish",
+        ["stop", "length", "tool_calls", "content_filter", "function_call"],
+    )
+    def test_all_canonical_finish_reasons_pass(self, finish: str) -> None:
+        result = va._live_chat_normalize(_openai_response(finish=finish), _context())
+        assert result["finishReasonInEnum"] is True
+
+    def test_anthropic_shape_maps_stop_reason(self) -> None:
+        block = MagicMock()
+        block.text = "Hi there"
+        response = MagicMock(spec=["role", "content", "stop_reason"])
+        response.role = "assistant"
+        response.content = [block]
+        response.stop_reason = "end_turn"
+        result = va._live_chat_normalize(response, _context())
+        assert result == {
+            "role": "assistant",
+            "contentNonEmpty": True,
+            "finishReasonInEnum": True,
+        }
+
+
+# ---------------------------------------------------------------------------
+# Live end-to-end (deselected by default; real network call when keys present)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.integration
+class TestLiveChatEndToEnd:
+    def test_openai_live_chat_structure(self) -> None:
+        import os
+
+        if not os.environ.get("OPENAI_API_KEY"):
+            pytest.skip("requirement unavailable: provider:openai")
+        resolved = {
+            "provider": "openai",
+            "model": os.environ.get("OPENAI_MODEL", "gpt-4o-mini"),
+            "apiKey": os.environ["OPENAI_API_KEY"],
+            "messages": [{"role": "user", "content": "Say hello in exactly one word."}],
+            "options": {"temperature": 0, "maxOutputTokens": 16},
+        }
+        context = _context(vector={"input": resolved})
+        observed = va._live_chat_invoke(resolved, context)
+        structure = va._live_chat_normalize(observed, context)
+        assert structure["role"] == "assistant"
+        assert structure["contentNonEmpty"] is True
+        assert structure["finishReasonInEnum"] is True

--- a/runtime/python/prompty/tests/model/vector_adapters.py
+++ b/runtime/python/prompty/tests/model/vector_adapters.py
@@ -1096,6 +1096,237 @@ def _run_turn_invoke(resolved_input: Any, context: dict[str, Any]) -> dict[str, 
 
 
 # ---------------------------------------------------------------------------
+# LIVE PROVIDER CONFORMANCE (capability-gated, structure-not-content)
+# ---------------------------------------------------------------------------
+#
+# Live vectors call a real provider API and assert STRUCTURE, not content: a
+# chat completion must reduce to an assistant message with non-empty content and
+# a finishReason drawn from the canonical enum. They self-skip when the required
+# capability/credential is absent, via the Typra >= 1.1.0 capability guard.
+#
+# A vector declares an ordered ``requires`` list of capability tokens, e.g.::
+#
+#     "requires": ["provider:openai"]
+#
+# The generated harness resolves each token against ``VECTOR_CAPABILITIES``
+# (below) in author order and, on the first predicate that returns falsy, calls
+# ``pytest.skip("requirement unavailable: <token>")``. A token with no registered
+# predicate is a HARD failure -- @vector conformance never skips silently. The
+# emitter treats tokens as opaque strings; the ``namespace:name`` grammar is an
+# authoring convention only. Env-presence is just ONE predicate flavor:
+# ``entra:foundry-project`` is a token PROBE (can we mint an Entra token for the
+# project URL), and ``var:live-enabled`` is a plain feature flag -- neither is a
+# bare env-key lookup.
+#
+# Canonical live-chat vector ``input`` (opaque to the emitter; the harness
+# resolves ``$env``/``$file``/``$json`` refs before invoke)::
+#
+#     {
+#       "provider": "openai",
+#       "model":    "gpt-4o-mini",              # or {"$env": "OPENAI_MODEL"}
+#       "apiKey":   {"$env": "OPENAI_API_KEY"},
+#       "endpoint": {"$env": "OPENAI_BASE_URL"},  # optional
+#       "messages": [{"role": "user", "content": "Say hello in one word."}],
+#       "options":  {"temperature": 0, "maxOutputTokens": 16}
+#     }
+#
+# and its structural ``expected``::
+#
+#     {"role": "assistant", "contentNonEmpty": true, "finishReasonInEnum": true}
+
+_FINISH_REASONS = {"stop", "length", "tool_calls", "content_filter", "function_call"}
+
+# Anthropic stop reasons mapped onto the canonical finishReason enum so the
+# structural shape is provider-agnostic.
+_ANTHROPIC_STOP_REASONS = {"end_turn": "stop", "max_tokens": "length", "tool_use": "tool_calls"}
+
+
+def _cap_provider_openai(context: dict) -> bool:
+    """Capability ``provider:openai`` -- an OpenAI API key is present."""
+    return bool(os.environ.get("OPENAI_API_KEY"))
+
+
+def _cap_provider_anthropic(context: dict) -> bool:
+    """Capability ``provider:anthropic`` -- an Anthropic API key is present."""
+    return bool(os.environ.get("ANTHROPIC_API_KEY"))
+
+
+def _cap_provider_azure(context: dict) -> bool:
+    """Capability ``provider:azure`` / ``provider:foundry`` -- Azure key auth is present."""
+    return bool(
+        os.environ.get("AZURE_OPENAI_API_KEY")
+        and os.environ.get("AZURE_OPENAI_ENDPOINT")
+        and os.environ.get("AZURE_OPENAI_CHAT_DEPLOYMENT")
+    )
+
+
+def _cap_var_live_enabled(context: dict) -> bool:
+    """Capability ``var:live-enabled`` -- a plain feature flag (the 'variable' flavor).
+
+    This is deliberately NOT a credential: it lets a suite opt live vectors in or
+    out independently of whether keys happen to be present.
+    """
+    return os.environ.get("PROMPTY_LIVE_VECTORS", "").strip().lower() in {"1", "true", "yes", "on"}
+
+
+def _cap_entra_foundry_project(context: dict) -> bool:
+    """Capability ``entra:foundry-project`` -- a token PROBE, not an env-key check.
+
+    Resolves a project URL/endpoint (preferring the ref-resolved vector input,
+    falling back to ``AZURE_OPENAI_ENDPOINT``) and asks ``DefaultAzureCredential``
+    whether it can mint a Cognitive Services token. Any failure -- missing
+    ``azure-identity``, no endpoint, no signed-in identity -- means unavailable.
+    """
+    try:
+        from azure.identity import DefaultAzureCredential
+    except Exception:  # noqa: BLE001 -- azure-identity is optional
+        return False
+
+    endpoint = os.environ.get("AZURE_OPENAI_ENDPOINT", "")
+    resolve = context.get("resolveInput")
+    vector = context.get("vector") or {}
+    raw_input = vector.get("input")
+    if callable(resolve) and isinstance(raw_input, dict):
+        try:
+            resolved = resolve(raw_input)
+            if isinstance(resolved, dict):
+                endpoint = resolved.get("projectUrl") or resolved.get("endpoint") or endpoint
+        except Exception:  # noqa: BLE001 -- a bad ref must not crash the probe
+            pass
+    if not endpoint:
+        return False
+
+    try:
+        credential = DefaultAzureCredential(exclude_interactive_browser_credential=True)
+        token = credential.get_token("https://cognitiveservices.azure.com/.default")
+        return bool(getattr(token, "token", None))
+    except Exception:  # noqa: BLE001 -- no usable identity == capability absent
+        return False
+
+
+def _live_provider_impls(provider: str) -> tuple[Any, Any]:
+    """Return ``(executor, processor)`` instances for a live provider."""
+    normalized = (provider or "openai").lower()
+    if normalized == "openai":
+        from prompty.providers.openai.executor import OpenAIExecutor
+        from prompty.providers.openai.processor import OpenAIProcessor
+
+        return OpenAIExecutor(), OpenAIProcessor()
+    if normalized in ("foundry", "azure"):
+        from prompty.providers.foundry.executor import FoundryExecutor
+        from prompty.providers.foundry.processor import FoundryProcessor
+
+        return FoundryExecutor(), FoundryProcessor()
+    if normalized == "anthropic":
+        from prompty.providers.anthropic.executor import AnthropicExecutor
+        from prompty.providers.anthropic.processor import AnthropicProcessor
+
+        return AnthropicExecutor(), AnthropicProcessor()
+    raise ValueError(f"live-chat adapter: unknown provider {provider!r}")
+
+
+def _build_live_agent(resolved_input: dict) -> Any:
+    """Construct a chat ``Agent`` from a resolved live-chat vector input."""
+    from prompty.model import Agent
+
+    provider = (resolved_input.get("provider") or "openai").lower()
+    api_key = resolved_input.get("apiKey")
+    endpoint = resolved_input.get("endpoint")
+
+    if provider in ("foundry", "azure") and not api_key:
+        # Entra ID path: no key, DefaultAzureCredential drives auth.
+        connection: dict[str, Any] = {"kind": "foundry"}
+        if endpoint:
+            connection["endpoint"] = endpoint
+    else:
+        connection = {"kind": "key"}
+        if api_key:
+            connection["apiKey"] = api_key
+        if endpoint:
+            connection["endpoint"] = endpoint
+
+    data: dict[str, Any] = {
+        "name": "live-chat-vector",
+        "model": {
+            "id": resolved_input.get("model") or "gpt-4o-mini",
+            "provider": provider,
+            "apiType": "chat",
+            "connection": connection,
+        },
+    }
+    options = resolved_input.get("options")
+    if options:
+        data["model"]["options"] = options
+    return Agent.load(data)
+
+
+def _extract_chat_structure(observed: Any) -> tuple[Any, Any, Any]:
+    """Reduce a raw provider chat response to ``(role, content, finishReason)``."""
+    # OpenAI / Foundry: ChatCompletion.choices[0].message + .finish_reason
+    choices = getattr(observed, "choices", None)
+    if not choices and isinstance(observed, dict):
+        choices = observed.get("choices")
+    if choices:
+        choice = choices[0]
+        message = getattr(choice, "message", None)
+        if message is None and isinstance(choice, dict):
+            message = choice.get("message")
+        role = getattr(message, "role", None)
+        content = getattr(message, "content", None)
+        if isinstance(message, dict):
+            role = message.get("role")
+            content = message.get("content")
+        finish = getattr(choice, "finish_reason", None)
+        if isinstance(choice, dict):
+            finish = choice.get("finish_reason")
+        return role, content, finish
+
+    # Anthropic Messages: .role, .content (list of blocks), .stop_reason
+    role = getattr(observed, "role", None)
+    content = getattr(observed, "content", None)
+    if isinstance(content, list):
+        parts = []
+        for block in content:
+            text = getattr(block, "text", None)
+            if text is None and isinstance(block, dict):
+                text = block.get("text")
+            if text:
+                parts.append(text)
+        content = "".join(parts)
+    finish = getattr(observed, "stop_reason", None)
+    finish = _ANTHROPIC_STOP_REASONS.get(finish, finish)
+    return role, content, finish
+
+
+def _live_chat_invoke(resolved_input: dict, context: dict) -> Any:
+    """Call a real provider and return its raw chat response.
+
+    Only reached when the capability guard has already confirmed the required
+    credentials/capabilities are present, so this makes a genuine network call.
+    """
+    from prompty.core.types import Message, TextPart
+
+    messages_spec = resolved_input.get("messages") or []
+    messages = [
+        Message(role=spec.get("role", "user"), parts=[TextPart(value=spec.get("content", ""))])
+        for spec in messages_spec
+    ]
+    agent = _build_live_agent(resolved_input)
+    executor, _processor = _live_provider_impls(resolved_input.get("provider") or "openai")
+    return executor.execute(agent, messages)
+
+
+def _live_chat_normalize(observed: Any, context: dict) -> dict:
+    """Project a raw chat response onto the canonical structural shape."""
+    role, content, finish = _extract_chat_structure(observed)
+    return {
+        "role": role,
+        "contentNonEmpty": bool(content and str(content).strip()),
+        "finishReasonInEnum": finish in _FINISH_REASONS,
+    }
+
+
+# ---------------------------------------------------------------------------
 # Adapter registry
 # ---------------------------------------------------------------------------
 
@@ -1112,6 +1343,7 @@ VECTOR_ADAPTERS: dict[str, Any] = {
     "DiscoveryConformance.enrich": {"invoke": _discovery_enrich_invoke},
     "DiscoveryConformance.mapModel": {"invoke": _discovery_map_invoke},
     "TurnConformance.replay": {"invoke": _replay_invoke},
+    "LiveChatConformance.complete": {"invoke": _live_chat_invoke, "normalize": _live_chat_normalize},
 }
 
 # Contracts introduced/tightened by Typra 0.12.0 that the Python runtime does not
@@ -1120,3 +1352,18 @@ VECTOR_ADAPTERS: dict[str, Any] = {
 VECTOR_WAIVERS: dict[str, str] = {}
 
 VECTOR_DOUBLES: dict[str, Any] = {}
+
+# Capability predicates for the Typra >= 1.1.0 requirement guard. The generated
+# harness loads this via ``getattr(_ADAPTER_MODULE, "VECTOR_CAPABILITIES", {})``,
+# so it is backward-compatible with harnesses that predate the guard. Each token
+# maps to ``predicate(context) -> bool`` (truthy = available). ``context`` is the
+# same object adapters receive (contract, operation, vector, provider, targetApi,
+# doubles, baseDir, resolveInput), so probes can inspect the resolved input.
+VECTOR_CAPABILITIES: dict[str, Any] = {
+    "provider:openai": _cap_provider_openai,
+    "provider:anthropic": _cap_provider_anthropic,
+    "provider:azure": _cap_provider_azure,
+    "provider:foundry": _cap_provider_azure,
+    "entra:foundry-project": _cap_entra_foundry_project,
+    "var:live-enabled": _cap_var_live_enabled,
+}


### PR DESCRIPTION
Combines the docs and Stage A code for the live-provider conformance work into a single mergeable PR. (Supersedes #510, now closed.)

## 1. Docs — `release-versioning-proposal.md`

Adds the proposal at the repo root (next to `RELEASING.md`) for a **two-layer versioning strategy**:

- **Layer 1** — a stable `.prompty` **format version** (the on-disk contract)
- **Layer 2** — **independent semantic versioning** per runtime, once we exit beta

§9 documents the **live provider conformance vector** design: structure-not-content assertions against real provider APIs (OpenAI / Anthropic / Foundry), emitted into every language runtime via the Typra emitter, with **capability-gated self-skipping** when provider credentials/capabilities are absent.

## 2. Code — Stage A Python runtime reference

- `tests/model/vector_adapters.py` — `VECTOR_CAPABILITIES` predicates (`provider:openai`, `provider:anthropic`, `provider:azure`, `provider:foundry`, `entra:foundry-project` token probe, `var:live-enabled`) + a structure-not-content `LiveChatConformance.complete` adapter that reduces OpenAI/Foundry/Anthropic responses to `{role, contentNonEmpty, finishReasonInEnum}`.
- `tests/model/test_capability_guard_reference.py` — pins the Typra 1.1.0 two-pass guard contract: unknown token → `AssertionError` ("never skips silently"), absent capability → `pytest.skip("requirement unavailable: <token>")`, author-order first-falsy; plus normalize-shape tests and a deselected live integration test.

Validation: ruff clean; `201 passed, 1 deselected` (the live test) on the `tests/model` suite.

## Out of scope (Stage B)

The schema `requires` vector + emitter pin bump to `^1.1.0` + regenerate are intentionally **not** included — blocked on the Typra emitter 1.1.0 publishing to npm.
