### PR TITLE
feat(python): live provider capability guard reference

### DIFF
--- a/runtime/python/prompty/tests/model/test_capability_guard_reference.py
+++ b/runtime/python/prompty/tests/model/test_capability_guard_reference.py
@@ -1,0 +1,272 @@
+"""Reference tests for the live-provider capability guard seam.
+
+These tests pin the Python side of the cross-runtime capability guard contract
+shipped in the Typra emitter (>= 1.1.0). They exercise:
+
+* the ``VECTOR_CAPABILITIES`` predicates in ``vector_adapters`` (present/absent),
+* a faithful LOCAL REPLICA of the emitter's two-pass guard so the skip/hard-fail
+  semantics are verified without waiting for a regenerated harness, and
+* the structure-not-content ``_live_chat_normalize`` projection.
+
+The generated harness (``test_vector_conformance.py``) only invokes the guard
+once a schema vector declares ``requires`` AND the emitter pin is bumped to
+1.1.0. Until then, ``_reference_guard`` below stands in for that emitted logic so
+the semantics stay locked and testable.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+from pathlib import Path
+from typing import Any
+from unittest.mock import MagicMock
+
+import pytest
+from _pytest.outcomes import Skipped
+
+# Load the sibling adapter module by path so the test is independent of sys.path
+# quirks (tests/model has no __init__.py; the harness itself loads it by path).
+_SPEC = importlib.util.spec_from_file_location("vector_adapters_ref", Path(__file__).with_name("vector_adapters.py"))
+assert _SPEC is not None and _SPEC.loader is not None
+va = importlib.util.module_from_spec(_SPEC)
+_SPEC.loader.exec_module(va)
+
+
+# ---------------------------------------------------------------------------
+# Local replica of the emitted guard (mirrors the Typra >= 1.1.0 contract).
+# ---------------------------------------------------------------------------
+
+_UNKNOWN_TOKEN_MESSAGE = (
+    'No capability predicate registered for requirement token "{token}". '
+    'Register VECTOR_CAPABILITIES["{token}"] in the module referenced by '
+    "'vector-adapter-path'. @vector conformance never skips silently."
+)
+
+
+def _reference_guard(requires: list[str], context: dict, capabilities: dict[str, Any]) -> None:
+    """Two-pass guard identical in spirit to the emitted harness code.
+
+    Pass 1 (registration): every token must be registered, else HARD failure.
+    Pass 2 (availability): first falsy predicate -> ``pytest.skip`` with the
+    canonical reason. Both passes walk ``requires`` in author order, never sorted.
+    """
+    for token in requires:
+        if token not in capabilities:
+            raise AssertionError(_UNKNOWN_TOKEN_MESSAGE.format(token=token))
+    for token in requires:
+        if not capabilities[token](context):
+            pytest.skip(f"requirement unavailable: {token}")
+
+
+def _context(**overrides: Any) -> dict:
+    base: dict[str, Any] = {
+        "contract": "LiveChatConformance",
+        "operation": "complete",
+        "vector": {},
+        "provider": "openai",
+        "targetApi": None,
+        "doubles": {},
+        "baseDir": ".",
+        "resolveInput": lambda value: value,
+    }
+    base.update(overrides)
+    return base
+
+
+# ---------------------------------------------------------------------------
+# VECTOR_CAPABILITIES registration
+# ---------------------------------------------------------------------------
+
+
+class TestCapabilitiesTable:
+    def test_expected_tokens_registered(self) -> None:
+        caps = va.VECTOR_CAPABILITIES
+        for token in (
+            "provider:openai",
+            "provider:anthropic",
+            "provider:azure",
+            "provider:foundry",
+            "entra:foundry-project",
+            "var:live-enabled",
+        ):
+            assert token in caps, f"missing capability token: {token}"
+            assert callable(caps[token])
+
+    def test_tokens_follow_grammar(self) -> None:
+        import re
+
+        pattern = re.compile(r"^[a-z0-9][a-z0-9-]*:[a-z0-9][a-z0-9-]*$")
+        for token in va.VECTOR_CAPABILITIES:
+            assert pattern.match(token), f"token violates namespace:name grammar: {token}"
+
+
+# ---------------------------------------------------------------------------
+# Individual predicate behavior (absent by default, present when env is set)
+# ---------------------------------------------------------------------------
+
+
+class TestProviderPredicates:
+    def test_openai_absent_then_present(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.delenv("OPENAI_API_KEY", raising=False)
+        assert va._cap_provider_openai(_context()) is False
+        monkeypatch.setenv("OPENAI_API_KEY", "sk-test")
+        assert va._cap_provider_openai(_context()) is True
+
+    def test_anthropic_absent_then_present(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.delenv("ANTHROPIC_API_KEY", raising=False)
+        assert va._cap_provider_anthropic(_context()) is False
+        monkeypatch.setenv("ANTHROPIC_API_KEY", "sk-ant-test")
+        assert va._cap_provider_anthropic(_context()) is True
+
+    def test_azure_requires_all_three(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.delenv("AZURE_OPENAI_API_KEY", raising=False)
+        monkeypatch.delenv("AZURE_OPENAI_ENDPOINT", raising=False)
+        monkeypatch.delenv("AZURE_OPENAI_CHAT_DEPLOYMENT", raising=False)
+        assert va._cap_provider_azure(_context()) is False
+
+        monkeypatch.setenv("AZURE_OPENAI_API_KEY", "key")
+        assert va._cap_provider_azure(_context()) is False  # endpoint + deployment still missing
+        monkeypatch.setenv("AZURE_OPENAI_ENDPOINT", "https://x.openai.azure.com/")
+        assert va._cap_provider_azure(_context()) is False  # deployment still missing
+        monkeypatch.setenv("AZURE_OPENAI_CHAT_DEPLOYMENT", "gpt-4o-mini")
+        assert va._cap_provider_azure(_context()) is True
+
+    def test_var_live_enabled_toggle(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.delenv("PROMPTY_LIVE_VECTORS", raising=False)
+        assert va._cap_var_live_enabled(_context()) is False
+        for truthy in ("1", "true", "TRUE", "yes", "on"):
+            monkeypatch.setenv("PROMPTY_LIVE_VECTORS", truthy)
+            assert va._cap_var_live_enabled(_context()) is True
+        for falsy in ("0", "false", "no", "off", ""):
+            monkeypatch.setenv("PROMPTY_LIVE_VECTORS", falsy)
+            assert va._cap_var_live_enabled(_context()) is False
+
+    def test_entra_probe_false_without_endpoint(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        # No endpoint anywhere -> probe short-circuits to False without needing
+        # azure-identity or a signed-in identity.
+        monkeypatch.delenv("AZURE_OPENAI_ENDPOINT", raising=False)
+        assert va._cap_entra_foundry_project(_context(vector={})) is False
+
+
+# ---------------------------------------------------------------------------
+# Guard semantics (via the local replica)
+# ---------------------------------------------------------------------------
+
+
+class TestGuardSemantics:
+    def test_unknown_token_hard_fails(self) -> None:
+        with pytest.raises(AssertionError) as exc:
+            _reference_guard(["bogus:token"], _context(), va.VECTOR_CAPABILITIES)
+        message = str(exc.value)
+        assert 'No capability predicate registered for requirement token "bogus:token".' in message
+        assert "@vector conformance never skips silently." in message
+
+    def test_absent_capability_skips_with_canonical_reason(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.delenv("OPENAI_API_KEY", raising=False)
+        with pytest.raises(Skipped) as exc:
+            _reference_guard(["provider:openai"], _context(), va.VECTOR_CAPABILITIES)
+        assert exc.value.msg == "requirement unavailable: provider:openai"
+
+    def test_present_capability_proceeds(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setenv("OPENAI_API_KEY", "sk-test")
+        # No skip, no error -> returns None.
+        assert _reference_guard(["provider:openai"], _context(), va.VECTOR_CAPABILITIES) is None
+
+    def test_author_order_first_falsy_wins(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        # Both absent; the FIRST token in author order must be the skip reason.
+        monkeypatch.delenv("PROMPTY_LIVE_VECTORS", raising=False)
+        monkeypatch.delenv("OPENAI_API_KEY", raising=False)
+        with pytest.raises(Skipped) as exc:
+            _reference_guard(["var:live-enabled", "provider:openai"], _context(), va.VECTOR_CAPABILITIES)
+        assert exc.value.msg == "requirement unavailable: var:live-enabled"
+
+    def test_registration_pass_precedes_availability(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        # An unknown token AFTER an absent-but-known token must still HARD fail:
+        # registration (pass 1) runs fully before availability (pass 2).
+        monkeypatch.delenv("OPENAI_API_KEY", raising=False)
+        with pytest.raises(AssertionError):
+            _reference_guard(["provider:openai", "bogus:token"], _context(), va.VECTOR_CAPABILITIES)
+
+
+# ---------------------------------------------------------------------------
+# Structure-not-content normalization
+# ---------------------------------------------------------------------------
+
+
+def _openai_response(role: str = "assistant", content: str = "Hello", finish: str = "stop") -> Any:
+    message = MagicMock()
+    message.role = role
+    message.content = content
+    choice = MagicMock()
+    choice.message = message
+    choice.finish_reason = finish
+    response = MagicMock()
+    response.choices = [choice]
+    return response
+
+
+class TestLiveChatNormalize:
+    def test_openai_shape_reduces_to_structure(self) -> None:
+        result = va._live_chat_normalize(_openai_response(), _context())
+        assert result == {
+            "role": "assistant",
+            "contentNonEmpty": True,
+            "finishReasonInEnum": True,
+        }
+
+    def test_empty_content_flags_false(self) -> None:
+        result = va._live_chat_normalize(_openai_response(content="   "), _context())
+        assert result["contentNonEmpty"] is False
+
+    def test_finish_reason_outside_enum_flags_false(self) -> None:
+        result = va._live_chat_normalize(_openai_response(finish="explode"), _context())
+        assert result["finishReasonInEnum"] is False
+
+    @pytest.mark.parametrize(
+        "finish",
+        ["stop", "length", "tool_calls", "content_filter", "function_call"],
+    )
+    def test_all_canonical_finish_reasons_pass(self, finish: str) -> None:
+        result = va._live_chat_normalize(_openai_response(finish=finish), _context())
+        assert result["finishReasonInEnum"] is True
+
+    def test_anthropic_shape_maps_stop_reason(self) -> None:
+        block = MagicMock()
+        block.text = "Hi there"
+        response = MagicMock(spec=["role", "content", "stop_reason"])
+        response.role = "assistant"
+        response.content = [block]
+        response.stop_reason = "end_turn"
+        result = va._live_chat_normalize(response, _context())
+        assert result == {
+            "role": "assistant",
+            "contentNonEmpty": True,
+            "finishReasonInEnum": True,
+        }
+
+
+# ---------------------------------------------------------------------------
+# Live end-to-end (deselected by default; real network call when keys present)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.integration
+class TestLiveChatEndToEnd:
+    def test_openai_live_chat_structure(self) -> None:
+        import os
+
+        if not os.environ.get("OPENAI_API_KEY"):
+            pytest.skip("requirement unavailable: provider:openai")
+        resolved = {
+            "provider": "openai",
+            "model": os.environ.get("OPENAI_MODEL", "gpt-4o-mini"),
+            "apiKey": os.environ["OPENAI_API_KEY"],
+            "messages": [{"role": "user", "content": "Say hello in exactly one word."}],
+            "options": {"temperature": 0, "maxOutputTokens": 16},
+        }
+        context = _context(vector={"input": resolved})
+        observed = va._live_chat_invoke(resolved, context)
+        structure = va._live_chat_normalize(observed, context)
+        assert structure["role"] == "assistant"
+        assert structure["contentNonEmpty"] is True
+        assert structure["finishReasonInEnum"] is True

--- a/runtime/python/prompty/tests/model/vector_adapters.py
+++ b/runtime/python/prompty/tests/model/vector_adapters.py
@@ -1096,6 +1096,237 @@ def _run_turn_invoke(resolved_input: Any, context: dict[str, Any]) -> dict[str, 
 
 
 # ---------------------------------------------------------------------------
+# LIVE PROVIDER CONFORMANCE (capability-gated, structure-not-content)
+# ---------------------------------------------------------------------------
+#
+# Live vectors call a real provider API and assert STRUCTURE, not content: a
+# chat completion must reduce to an assistant message with non-empty content and
+# a finishReason drawn from the canonical enum. They self-skip when the required
+# capability/credential is absent, via the Typra >= 1.1.0 capability guard.
+#
+# A vector declares an ordered ``requires`` list of capability tokens, e.g.::
+#
+#     "requires": ["provider:openai"]
+#
+# The generated harness resolves each token against ``VECTOR_CAPABILITIES``
+# (below) in author order and, on the first predicate that returns falsy, calls
+# ``pytest.skip("requirement unavailable: <token>")``. A token with no registered
+# predicate is a HARD failure -- @vector conformance never skips silently. The
+# emitter treats tokens as opaque strings; the ``namespace:name`` grammar is an
+# authoring convention only. Env-presence is just ONE predicate flavor:
+# ``entra:foundry-project`` is a token PROBE (can we mint an Entra token for the
+# project URL), and ``var:live-enabled`` is a plain feature flag -- neither is a
+# bare env-key lookup.
+#
+# Canonical live-chat vector ``input`` (opaque to the emitter; the harness
+# resolves ``$env``/``$file``/``$json`` refs before invoke)::
+#
+#     {
+#       "provider": "openai",
+#       "model":    "gpt-4o-mini",              # or {"$env": "OPENAI_MODEL"}
+#       "apiKey":   {"$env": "OPENAI_API_KEY"},
+#       "endpoint": {"$env": "OPENAI_BASE_URL"},  # optional
+#       "messages": [{"role": "user", "content": "Say hello in one word."}],
+#       "options":  {"temperature": 0, "maxOutputTokens": 16}
+#     }
+#
+# and its structural ``expected``::
+#
+#     {"role": "assistant", "contentNonEmpty": true, "finishReasonInEnum": true}
+
+_FINISH_REASONS = {"stop", "length", "tool_calls", "content_filter", "function_call"}
+
+# Anthropic stop reasons mapped onto the canonical finishReason enum so the
+# structural shape is provider-agnostic.
+_ANTHROPIC_STOP_REASONS = {"end_turn": "stop", "max_tokens": "length", "tool_use": "tool_calls"}
+
+
+def _cap_provider_openai(context: dict) -> bool:
+    """Capability ``provider:openai`` -- an OpenAI API key is present."""
+    return bool(os.environ.get("OPENAI_API_KEY"))
+
+
+def _cap_provider_anthropic(context: dict) -> bool:
+    """Capability ``provider:anthropic`` -- an Anthropic API key is present."""
+    return bool(os.environ.get("ANTHROPIC_API_KEY"))
+
+
+def _cap_provider_azure(context: dict) -> bool:
+    """Capability ``provider:azure`` / ``provider:foundry`` -- Azure key auth is present."""
+    return bool(
+        os.environ.get("AZURE_OPENAI_API_KEY")
+        and os.environ.get("AZURE_OPENAI_ENDPOINT")
+        and os.environ.get("AZURE_OPENAI_CHAT_DEPLOYMENT")
+    )
+
+
+def _cap_var_live_enabled(context: dict) -> bool:
+    """Capability ``var:live-enabled`` -- a plain feature flag (the 'variable' flavor).
+
+    This is deliberately NOT a credential: it lets a suite opt live vectors in or
+    out independently of whether keys happen to be present.
+    """
+    return os.environ.get("PROMPTY_LIVE_VECTORS", "").strip().lower() in {"1", "true", "yes", "on"}
+
+
+def _cap_entra_foundry_project(context: dict) -> bool:
+    """Capability ``entra:foundry-project`` -- a token PROBE, not an env-key check.
+
+    Resolves a project URL/endpoint (preferring the ref-resolved vector input,
+    falling back to ``AZURE_OPENAI_ENDPOINT``) and asks ``DefaultAzureCredential``
+    whether it can mint a Cognitive Services token. Any failure -- missing
+    ``azure-identity``, no endpoint, no signed-in identity -- means unavailable.
+    """
+    try:
+        from azure.identity import DefaultAzureCredential
+    except Exception:  # noqa: BLE001 -- azure-identity is optional
+        return False
+
+    endpoint = os.environ.get("AZURE_OPENAI_ENDPOINT", "")
+    resolve = context.get("resolveInput")
+    vector = context.get("vector") or {}
+    raw_input = vector.get("input")
+    if callable(resolve) and isinstance(raw_input, dict):
+        try:
+            resolved = resolve(raw_input)
+            if isinstance(resolved, dict):
+                endpoint = resolved.get("projectUrl") or resolved.get("endpoint") or endpoint
+        except Exception:  # noqa: BLE001 -- a bad ref must not crash the probe
+            pass
+    if not endpoint:
+        return False
+
+    try:
+        credential = DefaultAzureCredential(exclude_interactive_browser_credential=True)
+        token = credential.get_token("https://cognitiveservices.azure.com/.default")
+        return bool(getattr(token, "token", None))
+    except Exception:  # noqa: BLE001 -- no usable identity == capability absent
+        return False
+
+
+def _live_provider_impls(provider: str) -> tuple[Any, Any]:
+    """Return ``(executor, processor)`` instances for a live provider."""
+    normalized = (provider or "openai").lower()
+    if normalized == "openai":
+        from prompty.providers.openai.executor import OpenAIExecutor
+        from prompty.providers.openai.processor import OpenAIProcessor
+
+        return OpenAIExecutor(), OpenAIProcessor()
+    if normalized in ("foundry", "azure"):
+        from prompty.providers.foundry.executor import FoundryExecutor
+        from prompty.providers.foundry.processor import FoundryProcessor
+
+        return FoundryExecutor(), FoundryProcessor()
+    if normalized == "anthropic":
+        from prompty.providers.anthropic.executor import AnthropicExecutor
+        from prompty.providers.anthropic.processor import AnthropicProcessor
+
+        return AnthropicExecutor(), AnthropicProcessor()
+    raise ValueError(f"live-chat adapter: unknown provider {provider!r}")
+
+
+def _build_live_agent(resolved_input: dict) -> Any:
+    """Construct a chat ``Agent`` from a resolved live-chat vector input."""
+    from prompty.model import Agent
+
+    provider = (resolved_input.get("provider") or "openai").lower()
+    api_key = resolved_input.get("apiKey")
+    endpoint = resolved_input.get("endpoint")
+
+    if provider in ("foundry", "azure") and not api_key:
+        # Entra ID path: no key, DefaultAzureCredential drives auth.
+        connection: dict[str, Any] = {"kind": "foundry"}
+        if endpoint:
+            connection["endpoint"] = endpoint
+    else:
+        connection = {"kind": "key"}
+        if api_key:
+            connection["apiKey"] = api_key
+        if endpoint:
+            connection["endpoint"] = endpoint
+
+    data: dict[str, Any] = {
+        "name": "live-chat-vector",
+        "model": {
+            "id": resolved_input.get("model") or "gpt-4o-mini",
+            "provider": provider,
+            "apiType": "chat",
+            "connection": connection,
+        },
+    }
+    options = resolved_input.get("options")
+    if options:
+        data["model"]["options"] = options
+    return Agent.load(data)
+
+
+def _extract_chat_structure(observed: Any) -> tuple[Any, Any, Any]:
+    """Reduce a raw provider chat response to ``(role, content, finishReason)``."""
+    # OpenAI / Foundry: ChatCompletion.choices[0].message + .finish_reason
+    choices = getattr(observed, "choices", None)
+    if not choices and isinstance(observed, dict):
+        choices = observed.get("choices")
+    if choices:
+        choice = choices[0]
+        message = getattr(choice, "message", None)
+        if message is None and isinstance(choice, dict):
+            message = choice.get("message")
+        role = getattr(message, "role", None)
+        content = getattr(message, "content", None)
+        if isinstance(message, dict):
+            role = message.get("role")
+            content = message.get("content")
+        finish = getattr(choice, "finish_reason", None)
+        if isinstance(choice, dict):
+            finish = choice.get("finish_reason")
+        return role, content, finish
+
+    # Anthropic Messages: .role, .content (list of blocks), .stop_reason
+    role = getattr(observed, "role", None)
+    content = getattr(observed, "content", None)
+    if isinstance(content, list):
+        parts = []
+        for block in content:
+            text = getattr(block, "text", None)
+            if text is None and isinstance(block, dict):
+                text = block.get("text")
+            if text:
+                parts.append(text)
+        content = "".join(parts)
+    finish = getattr(observed, "stop_reason", None)
+    finish = _ANTHROPIC_STOP_REASONS.get(finish, finish)
+    return role, content, finish
+
+
+def _live_chat_invoke(resolved_input: dict, context: dict) -> Any:
+    """Call a real provider and return its raw chat response.
+
+    Only reached when the capability guard has already confirmed the required
+    credentials/capabilities are present, so this makes a genuine network call.
+    """
+    from prompty.core.types import Message, TextPart
+
+    messages_spec = resolved_input.get("messages") or []
+    messages = [
+        Message(role=spec.get("role", "user"), parts=[TextPart(value=spec.get("content", ""))])
+        for spec in messages_spec
+    ]
+    agent = _build_live_agent(resolved_input)
+    executor, _processor = _live_provider_impls(resolved_input.get("provider") or "openai")
+    return executor.execute(agent, messages)
+
+
+def _live_chat_normalize(observed: Any, context: dict) -> dict:
+    """Project a raw chat response onto the canonical structural shape."""
+    role, content, finish = _extract_chat_structure(observed)
+    return {
+        "role": role,
+        "contentNonEmpty": bool(content and str(content).strip()),
+        "finishReasonInEnum": finish in _FINISH_REASONS,
+    }
+
+
+# ---------------------------------------------------------------------------
 # Adapter registry
 # ---------------------------------------------------------------------------
 
@@ -1112,6 +1343,7 @@ VECTOR_ADAPTERS: dict[str, Any] = {
     "DiscoveryConformance.enrich": {"invoke": _discovery_enrich_invoke},
     "DiscoveryConformance.mapModel": {"invoke": _discovery_map_invoke},
     "TurnConformance.replay": {"invoke": _replay_invoke},
+    "LiveChatConformance.complete": {"invoke": _live_chat_invoke, "normalize": _live_chat_normalize},
 }
 
 # Contracts introduced/tightened by Typra 0.12.0 that the Python runtime does not
@@ -1120,3 +1352,18 @@ VECTOR_ADAPTERS: dict[str, Any] = {
 VECTOR_WAIVERS: dict[str, str] = {}
 
 VECTOR_DOUBLES: dict[str, Any] = {}
+
+# Capability predicates for the Typra >= 1.1.0 requirement guard. The generated
+# harness loads this via ``getattr(_ADAPTER_MODULE, "VECTOR_CAPABILITIES", {})``,
+# so it is backward-compatible with harnesses that predate the guard. Each token
+# maps to ``predicate(context) -> bool`` (truthy = available). ``context`` is the
+# same object adapters receive (contract, operation, vector, provider, targetApi,
+# doubles, baseDir, resolveInput), so probes can inspect the resolved input.
+VECTOR_CAPABILITIES: dict[str, Any] = {
+    "provider:openai": _cap_provider_openai,
+    "provider:anthropic": _cap_provider_anthropic,
+    "provider:azure": _cap_provider_azure,
+    "provider:foundry": _cap_provider_azure,
+    "entra:foundry-project": _cap_entra_foundry_project,
+    "var:live-enabled": _cap_var_live_enabled,
+}


### PR DESCRIPTION
## Summary

This is the **code half** of a docs/code split. The companion doc (`release-versioning-proposal.md`) already went up as PR #509; this PR lands the Stage A "live provider conformance vectors" Python runtime reference.

It is the **version-independent Stage A runtime reference**, consisting of:

- **`VECTOR_CAPABILITIES` predicates** — capability guard predicates for the conformance vectors.
- **Structure-not-content `LiveChatConformance.complete` adapter** — validates response *structure* rather than content, so it stays stable across live providers.
- **A test that pins the Typra 1.1.0 two-pass guard contract** (`test_capability_guard_reference.py`) — locks in the expected two-pass capability-guard behavior.

## What's included

| File | Change |
| --- | --- |
| `runtime/python/prompty/tests/model/vector_adapters.py` | Modified — capability predicates + structural live adapter |
| `runtime/python/prompty/tests/model/test_capability_guard_reference.py` | New — pins the Typra 1.1.0 two-pass guard contract |

## Validation

- `uv run ruff check` — clean
- `uv run pytest tests/model/test_capability_guard_reference.py tests/model/test_vector_conformance.py -q` — **201 passed, 1 deselected** (the deselected live test requires real provider credentials, as expected)

## Explicitly out of scope

**Stage B is intentionally NOT included** and is blocked on the emitter `1.1.0` publishing to npm. Stage B covers:
- adding the schema `requires` vector
- bumping the emitter pin to `^1.1.0`
- regenerating the model

Co-authored-by: Copilot App <223556219+Copilot@users.noreply.github.com>