### PR TITLE
ci(dependabot): ignore TypeScript major (7.x) bumps until toolchain supports it

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -26,6 +26,13 @@ updates:
     schedule:
       interval: "weekly"
     open-pull-requests-limit: 10
+    # TypeScript 7 (the native/Go port) is not yet supported by our toolchain:
+    # ts-jest@29 requires `typescript >=4.3 <7` and tsup/esbuild crash against
+    # it (`useCaseSensitiveFileNames`). Hold typescript on the 5.x/6.x line until
+    # the toolchain catches up; remove this once ts-jest and tsup support 7.x.
+    ignore:
+      - dependency-name: "typescript"
+        update-types: ["version-update:semver-major"]
     groups:
       npm-security:
         applies-to: security-updates
@@ -98,6 +105,11 @@ updates:
     schedule:
       interval: "weekly"
     open-pull-requests-limit: 10
+    # See the 2.x note above: hold typescript on 5.x/6.x until ts-jest/tsup
+    # support the 7.x native port.
+    ignore:
+      - dependency-name: "typescript"
+        update-types: ["version-update:semver-major"]
     groups:
       npm-v1-version:
         applies-to: version-updates


### PR DESCRIPTION
## What

Adds a Dependabot `ignore` rule for `typescript` **major** version bumps (`version-update:semver-major`) in both npm ecosystems — the 2.x (default branch) block and the v1 block.

## Why

The npm version-update groups bumped `typescript` to `^7.0.2` — TypeScript 7, the new native/Go port — which our build/test toolchain doesn't support yet. This is the root cause of the failing Dependabot version PRs:

- **#514** (`npm-v1-version`): `npm ERESOLVE` — `ts-jest@29` requires `typescript >=4.3 <7`, conflicts with the bumped `typescript@^7`.
- **#513** (`npm-version`): `tsup`/esbuild crash — `TypeError: Cannot read properties of undefined (reading 'useCaseSensitiveFileNames')`, the classic esbuild/tsup ↔ TS7 incompatibility.

Holding `typescript` on the 5.x/6.x line keeps grouped version PRs green. The rule is scoped to **major** bumps only, so 5.x→5.y minor/patch updates still flow.

## Follow-up

Once this lands on `main`, re-trigger the affected PRs so they regenerate without the TS7 bump:

- `@dependabot recreate` on #513 and #514

Remove this ignore rule once `ts-jest` and `tsup` support TypeScript 7.