### PR TITLE
ci(dependabot): hold CI-breaking major bumps (setup-swift v3, rand 0.10)

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -71,6 +71,14 @@ updates:
     directory: "/"
     schedule:
       interval: "weekly"
+    # swift-actions/setup-swift v3 is broken on Linux: its Swiftly-based install
+    # fails GPG signature verification (`gpg: Can't check signature: No public
+    # key` -> `/usr/bin/gpg failed with exit code 2`). Upstream bug, still open:
+    # https://github.com/swift-actions/setup-swift/issues/798
+    # Hold at v2 until it's fixed; remove this once v3 installs cleanly.
+    ignore:
+      - dependency-name: "swift-actions/setup-swift"
+        update-types: ["version-update:semver-major"]
     groups:
       actions-security:
         applies-to: security-updates

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -59,6 +59,15 @@ updates:
     directory: "/runtime/rust"
     schedule:
       interval: "weekly"
+    # rand 0.10 is a breaking API change: it drops the `Rng::random()` /
+    # `random_range()` methods our code relies on (e.g. `rng.random()`,
+    # `rng.random_range(..)` in prompty and prompty-foundry), so the workspace
+    # fails to compile (`no method named `random` found for struct `ThreadRng``).
+    # Hold rand on 0.9 until the Rust source is migrated to the 0.10 API; remove
+    # this ignore as part of that migration.
+    ignore:
+      - dependency-name: "rand"
+        update-types: ["version-update:semver-major"]
     groups:
       cargo-security:
         applies-to: security-updates


### PR DESCRIPTION
## What

Adds Dependabot `ignore` rules for two **major** version bumps that break CI, so their grouped PRs regenerate green while still taking every other update in the group:

1. **`swift-actions/setup-swift`** — hold at v2 (`github-actions` ecosystem)
2. **`rand`** — hold at 0.9 (`cargo` ecosystem)

## Why

### setup-swift v3 (breaks #525)
The regenerated actions-version group (#525) bumps `swift-actions/setup-swift` v2→v3, which fails the Swift CI job on Linux:

```
gpg: Can't check signature: No public key
The process '/usr/bin/gpg' failed with exit code 2
```

Open upstream bug in the action's Swiftly-based installer: [swift-actions/setup-swift#798](https://github.com/swift-actions/setup-swift/issues/798). v2 works fine (Swift check is green on `main`). The group's `actions/setup-java` v6 and `gradle/actions/setup-gradle` v6 bumps pass and are unaffected.

### rand 0.10 (breaks #504)
The cargo-version group (#504) bumps `rand` 0.9→0.10, a breaking API change that removes the `Rng::random()` / `random_range()` methods our code uses, so the workspace no longer compiles across all 4 Rust matrix jobs:

```
error[E0599]: no method named `random` found for struct `ThreadRng`
error[E0599]: no method named `random_range` found for struct `ThreadRng`
```

Used in `prompty` (`parsers/prompty.rs`, `renderers/common.rs`, `pipeline/live_turn.rs`) and `prompty-foundry` (`oauth.rs`). `main` (rand 0.9) is green. Holding rand at 0.9 keeps the other 7 cargo bumps flowing.

## Effect

After merge, `@dependabot recreate` on #525 and #504 → both regenerate without the breaking major and go green.

## Follow-up

- **setup-swift**: remove the ignore once upstream v3 installs cleanly (track [#798](https://github.com/swift-actions/setup-swift/issues/798)).
- **rand**: this is *our* code to migrate — remove the ignore as part of a `rand` 0.9→0.10 source migration. Worth a tracking issue.