### PR TITLE
Fix release-please bootstrap-sha and cut Python 2.0.0

### DIFF
--- a/release-please-config.json
+++ b/release-please-config.json
@@ -3,7 +3,7 @@
   "separator": "/",
   "include-component-in-tag": true,
   "include-v-in-tag": false,
-  "bootstrap-sha": "3c1c0cc27ee429983ee362aa60ac510678da4af9",
+  "bootstrap-sha": "bc477ead",
   "changelog-sections": [
     { "type": "feat", "section": "Features" },
     { "type": "fix", "section": "Bug Fixes" },

--- a/runtime/python/prompty/CHANGELOG.md
+++ b/runtime/python/prompty/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 All notable changes to the Prompty Python runtime will be documented here.
 
-## [2.0.0-alpha.5] — Unreleased
+## [Unreleased]
 
 ### Added
 - §8.8 Structured Result Casting: `StructuredResult` dict subclass and `cast()` function for zero-copy typed deserialization (dataclass, Pydantic, TypedDict)


### PR DESCRIPTION
## Why

After #534 merged, the release-please workflow ran green but opened **0 Release PRs**. Root cause: the `bootstrap-sha` was pinned to `3c1c0cc2`, which turned out to be one parent of the #534 **merge commit**. The branch's own commits weren't descendants of that SHA, and release-please ignores merge commits + floors at `bootstrap-sha`, so it saw `Considering: 0 commits` for every runtime.

## What this does

1. **Repoints `bootstrap-sha`** `3c1c0cc2` → `bc477ead` (current main tip). This establishes a clean baseline: releases are considered from the merged state forward, so ordinary `feat`/`fix` commits going forward are correctly picked up.
2. **Cuts the first stable Python release** via a one-time `Release-As: 2.0.0` trigger commit scoped to `runtime/python/prompty/`. Python is the only runtime graduating now — it's the one we've actually validated this session (harness correctness, agent loop with live tool execution, Foundry provider).
3. **Normalizes a stale CHANGELOG heading** (`2.0.0-alpha.5 — Unreleased`, inconsistent with `_version.py`'s `2.0.0-beta.3`) to the standard `Unreleased` form.

## Scope

- **Python only.** The other six runtimes (C#, Java, Go, Rust, TypeScript, Swift) were **not built or tested** this session — they only received `x-release-please-version` annotations. They stay on their beta line and graduate individually once each is independently validated.

## After merge

- release-please runs on the push to `main` and should open a **Python `2.0.0`** Release PR. Merging that PR bumps `_version.py` → `2.0.0` and cuts the `python/2.0.0` tag.
- ⚠️ Still outstanding (admin): create the `RELEASE_PLEASE_TOKEN` secret so cut tags trigger the publish workflows. Without it, Release PRs open but publishing won't auto-fire.

Co-authored-by: Copilot App <223556219+Copilot@users.noreply.github.com>