### PR TITLE
ci(release): scope release-please to Python for first GA

### DIFF
--- a/release-please-config.json
+++ b/release-please-config.json
@@ -24,43 +24,6 @@
       "extra-files": [
         { "type": "generic", "path": "prompty/_version.py" }
       ]
-    },
-    "runtime/rust": {
-      "component": "rust",
-      "release-type": "rust"
-    },
-    "runtime/typescript/packages/core": {
-      "component": "typescript",
-      "release-type": "node",
-      "package-name": "@prompty/core"
-    },
-    "runtime/csharp": {
-      "component": "csharp",
-      "release-type": "simple",
-      "extra-files": [
-        { "type": "generic", "path": "Prompty.Core/Prompty.Core.csproj" },
-        { "type": "generic", "path": "Prompty.OpenAI/Prompty.OpenAI.csproj" },
-        { "type": "generic", "path": "Prompty.Foundry/Prompty.Foundry.csproj" },
-        { "type": "generic", "path": "Prompty.Anthropic/Prompty.Anthropic.csproj" }
-      ]
-    },
-    "runtime/java": {
-      "component": "java",
-      "release-type": "simple",
-      "extra-files": [
-        { "type": "generic", "path": "build.gradle.kts" }
-      ]
-    },
-    "runtime/go/prompty": {
-      "component": "go",
-      "release-type": "go"
-    },
-    "runtime/swift/prompty": {
-      "component": "swift",
-      "release-type": "simple"
     }
-  },
-  "plugins": [
-    "node-workspace"
-  ]
+  }
 }


### PR DESCRIPTION
## Why

After #535 merged, the release-please run **crashed**:

```
✖ is not a package manifest (might be a cargo workspace)
##[error]release-please failed: is not a package manifest (might be a cargo workspace)
```

The `rust` component pointed at `runtime/rust/Cargo.toml`, which is a **workspace** manifest, not a package manifest. release-please's rust updater can't parse it, and the error **aborts the entire run before any Release PR is created** — so it took the Python release down with it.

The run was also computing backlog releases for **typescript → 2.1.0-beta.5** and **rust → 2.1.0-beta.4** off their existing beta tags — runtimes we haven't validated yet.

## What this does

Scopes release-please to the **Python component only** for the first GA. This:
- Sidesteps the rust-workspace crash entirely.
- Stops the unwanted typescript/rust backlog releases.
- Lets the already-merged `feat(python): … Release-As: 2.0.0` commit (still in range after `bootstrap-sha`) open a clean **Python `2.0.0`** Release PR.

## Not lost — deferred

The other six components (rust, typescript, csharp, java, go, swift) and the `node-workspace` plugin are preserved in git history (see #534). They'll be **re-added one PR at a time as each runtime is validated** — a natural checkpoint to actually verify each before it can cut a release. The rust re-add must point at the **member manifests** (`runtime/rust/prompty`, `runtime/rust/prompty-openai`, …), not the workspace root.

## After merge

release-please runs on the push to `main` and should open a single **Python `2.0.0`** Release PR (rewrites `_version.py` → `2.0.0`, bumps the manifest, adds the CHANGELOG section).

Co-authored-by: Copilot App <223556219+Copilot@users.noreply.github.com>