### PR TITLE
ci(release): mint GitHub App token for release-please

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -5,10 +5,19 @@ name: release-please
 # (prompty-python.yml, prompty-rust.yml, prompty-ts-release.yml, prompty-csharp.yml)
 # trigger on those tags and do the actual package publishing.
 #
-# IMPORTANT: `token` must be a GitHub App installation token or a PAT — NOT the
-# default GITHUB_TOKEN. Tags created with GITHUB_TOKEN do not trigger the
-# tag-listening publish workflows (GitHub's recursive-workflow guard). Provide a
-# token via the RELEASE_PLEASE_TOKEN secret so the publish workflows fire.
+# IMPORTANT: the token used by release-please must NOT be the default
+# GITHUB_TOKEN, for two reasons:
+#   1. The microsoft org forbids GitHub Actions from creating/approving PRs, so
+#      the Actions bot cannot open the Release PR.
+#   2. Tags created with GITHUB_TOKEN do not trigger the tag-listening publish
+#      workflows (GitHub's recursive-workflow guard).
+# A GitHub App installation token (App identity, not the Actions bot) solves
+# both: it may create PRs and its tag pushes fire the publish workflows.
+#
+# Setup: create a GitHub App with Contents: read/write + Pull requests:
+# read/write, install it on this repo, then add repo secrets RELEASE_APP_ID and
+# RELEASE_APP_PRIVATE_KEY. Until those exist the workflow falls back to
+# RELEASE_PLEASE_TOKEN (a PAT) and finally github.token (which cannot open PRs).
 
 on:
   push:
@@ -24,8 +33,20 @@ jobs:
   release-please:
     runs-on: ubuntu-latest
     steps:
+      # Mint a GitHub App installation token when RELEASE_APP_ID /
+      # RELEASE_APP_PRIVATE_KEY are configured. continue-on-error keeps the job
+      # alive (falling back to a PAT / github.token) if the App secrets are
+      # absent, so merging this change never hard-breaks the pipeline.
+      - name: Mint GitHub App token
+        id: app-token
+        continue-on-error: true
+        uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
+        with:
+          app-id: ${{ secrets.RELEASE_APP_ID }}
+          private-key: ${{ secrets.RELEASE_APP_PRIVATE_KEY }}
+
       - uses: googleapis/release-please-action@a02a34c4d625f9be7cb89156071d8567266a2445 # v4
         with:
-          token: ${{ secrets.RELEASE_PLEASE_TOKEN || github.token }}
+          token: ${{ steps.app-token.outputs.token || secrets.RELEASE_PLEASE_TOKEN || github.token }}
           config-file: release-please-config.json
           manifest-file: .release-please-manifest.json


### PR DESCRIPTION
## Why

The microsoft org enforces a global policy that **GitHub Actions may not create or approve pull requests**. As a result, the `release-please` workflow running as `github-actions[bot]` can push the release branch but **cannot open the Release PR** — the run fails with `GitHub Actions is not permitted to create or approve pull requests`. No repo-level toggle can override this (the API returns `409 Conflict`).

## What

Rewire `.github/workflows/release-please.yml` to mint a **GitHub App installation token** via [`actions/create-github-app-token`](https://github.com/actions/create-github-app-token) (pinned to `v3.2.0`). An App identity (not the Actions bot) **is** allowed to create PRs, and — bonus — tags it cuts **do** trigger the tag-listening publish workflows, which the default `GITHUB_TOKEN` does not.

The token step is `continue-on-error: true` and the release-please `token` falls back through `RELEASE_PLEASE_TOKEN` → `github.token`, so **merging this before the App is configured never hard-breaks the pipeline**.

## Follow-up (one-time, repo admin)

1. Create a GitHub App with **Contents: read/write** + **Pull requests: read/write**.
2. Install it on `microsoft/prompty`.
3. Add repo secrets **`RELEASE_APP_ID`** and **`RELEASE_APP_PRIVATE_KEY`**.

Once those exist, re-run `release-please.yml` and it will open the Python `2.0.0` Release PR.

Co-authored-by: Copilot App <223556219+Copilot@users.noreply.github.com>